### PR TITLE
Improve `HOTRG` and `TRG` runtime

### DIFF
--- a/src/schemes/trg.jl
+++ b/src/schemes/trg.jl
@@ -27,7 +27,7 @@ function step!(scheme::TRG, trunc::TensorKit.TruncationScheme)
     end
 
     # @plansor complains here, not sure why
-    @tensor scheme.T[-1 -2; -3 -4] := D[-1 1; 4] * B[-2; 2 1] * C[2; 3 -3] * A[4 3; -4]
+    @tensor scheme.T[-1 -2; -3 -4] := D[-1 1; 4] * B[-2; 3 1] * C[3; 2 -3] * A[4 2; -4]
     return scheme
 end
 


### PR DESCRIPTION
Some minor but significant changes in terms of runtime. Choosing the best contraction order is very important.