### PR TITLE
Anisotropic TRG for three dimensions

### DIFF
--- a/src/TNRKit.jl
+++ b/src/TNRKit.jl
@@ -37,7 +37,7 @@ export run!
 # models
 include("models/ising.jl")
 export classical_ising, classical_ising_symmetric, potts_βc, ising_βc, f_onsager,
-       ising_βc_3D, classical_ising_symmetric_3D
+       ising_βc_3D, classical_ising_symmetric_3D, classical_ising_3D
 
 include("models/gross-neveu.jl")
 export gross_neveu_start

--- a/src/TNRKit.jl
+++ b/src/TNRKit.jl
@@ -19,6 +19,7 @@ include("schemes/looptnr.jl")
 include("schemes/c4ctm.jl")
 include("schemes/rctm.jl")
 include("schemes/ctmhotrg.jl")
+include("schemes/atrg3d.jl")
 
 export TNRScheme
 export TRG
@@ -29,12 +30,14 @@ export LoopTNR
 export c4CTM
 export rCTM
 export CTMHOTRG
+export ATRG_3D
 
 export run!
 
 # models
 include("models/ising.jl")
-export classical_ising, classical_ising_symmetric, potts_βc, ising_βc, f_onsager
+export classical_ising, classical_ising_symmetric, potts_βc, ising_βc, f_onsager,
+       ising_βc_3D, classical_ising_symmetric_3D
 
 include("models/gross-neveu.jl")
 export gross_neveu_start

--- a/src/models/ising.jl
+++ b/src/models/ising.jl
@@ -47,6 +47,6 @@ function classical_ising_symmetric_3D(β)
     return T
 end
 
-ising_βc_3D = 4.51152469
+ising_βc_3D = 1/4.51152469
 
 classical_ising_symmetric_3D() = classical_ising_symmetric_3D(ising_βc_3D)

--- a/src/models/ising.jl
+++ b/src/models/ising.jl
@@ -34,12 +34,13 @@ function classical_ising_symmetric_3D(β)
     y = sinh(β / 2)
     W = [sqrt(x) sqrt(y); sqrt(x) -sqrt(y)]
     T_array = zeros(Float64, 2, 2, 2, 2, 2, 2)
-
-    for a in 1:2
-        # Outer product of W[a, :] with itself 6 times
-        T_array .+= W[a, :] ⊗ W[a, :] ⊗ W[a, :] ⊗ W[a, :] ⊗ W[a, :] ⊗ W[a, :]
+    for (i, j, k, l, m, n) in Iterators.product([1:2 for _ in 1:6]...)
+        for a in 1:2
+            # Outer product of W[a, :] with itself 6 times
+            T_array[i, j, k, l, m, n] += W[a, i] * W[a, j] * W[a, k] * W[a, l] * W[a, m] *
+                                         W[a, n]
+        end
     end
-
     S = ℤ₂Space(0 => 1, 1 => 1)
     T = TensorMap(T_array, S ⊗ S ⊗ S ← S ⊗ S ⊗ S)
 

--- a/src/models/ising.jl
+++ b/src/models/ising.jl
@@ -59,14 +59,14 @@ function classical_ising_3D(; beta, J=1.0)
     O = zeros(2, 2, 2, 2, 2, 2)
     O[1, 1, 1, 1, 1, 1] = 1
     O[2, 2, 2, 2, 2, 2] = 1
-    @tensor o[-1 -2; -3 -4 -5 -6] :=
-        O[1 2; 3 4 5 6] * q[-1; 1] * q[-2; 2] * q[-3; 3] * q[-4; 4] * q[-5; 5] * q[-6; 6]
+    @tensor o[-1 -2; -3 -4 -5 -6] := O[1 2; 3 4 5 6] * q[-1; 1] * q[-2; 2] * q[-3; 3] *
+                                     q[-4; 4] * q[-5; 5] * q[-6; 6]
 
     TMS = ℂ^2 ⊗ (ℂ^2)' ← ℂ^2 ⊗ ℂ^2 ⊗ (ℂ^2)' ⊗ (ℂ^2)'
 
     return TensorMap(o, TMS)
 end
-ising_βc_3D = 1/4.51152469
+ising_βc_3D = 1 / 4.51152469
 
 classical_ising_symmetric_3D() = classical_ising_symmetric_3D(ising_βc_3D)
-classical_ising_3D() = classical_ising_3D(β=ising_βc_3D)
+classical_ising_3D() = classical_ising_3D(; β=ising_βc_3D)

--- a/src/models/ising.jl
+++ b/src/models/ising.jl
@@ -44,9 +44,29 @@ function classical_ising_symmetric_3D(β)
     S = ℤ₂Space(0 => 1, 1 => 1)
     T = TensorMap(T_array, S ⊗ S ⊗ S ← S ⊗ S ⊗ S)
 
-    return T
+    return permute(T, ((1, 4), (5, 6, 2, 3)))
 end
 
+function classical_ising_3D(; beta, J=1.0)
+    K = beta * J
+
+    # Boltzmann weights
+    t = ComplexF64[exp(K) exp(-K); exp(-K) exp(K)]
+    r = eigen(t)
+    q = r.vectors * sqrt(LinearAlgebra.Diagonal(r.values)) * r.vectors
+
+    # local partition function tensor
+    O = zeros(2, 2, 2, 2, 2, 2)
+    O[1, 1, 1, 1, 1, 1] = 1
+    O[2, 2, 2, 2, 2, 2] = 1
+    @tensor o[-1 -2; -3 -4 -5 -6] :=
+        O[1 2; 3 4 5 6] * q[-1; 1] * q[-2; 2] * q[-3; 3] * q[-4; 4] * q[-5; 5] * q[-6; 6]
+
+    TMS = ℂ^2 ⊗ (ℂ^2)' ← ℂ^2 ⊗ ℂ^2 ⊗ (ℂ^2)' ⊗ (ℂ^2)'
+
+    return TensorMap(o, TMS)
+end
 ising_βc_3D = 1/4.51152469
 
 classical_ising_symmetric_3D() = classical_ising_symmetric_3D(ising_βc_3D)
+classical_ising_3D() = classical_ising_3D(β=ising_βc_3D)

--- a/src/models/ising.jl
+++ b/src/models/ising.jl
@@ -45,3 +45,7 @@ function classical_ising_symmetric_3D(β)
 
     return T
 end
+
+ising_βc_3D = 4.51152469
+
+classical_ising_symmetric_3D() = classical_ising_symmetric_3D(ising_βc_3D)

--- a/src/models/ising.jl
+++ b/src/models/ising.jl
@@ -30,8 +30,8 @@ classical_ising_symmetric() = classical_ising_symmetric(ising_βc)
 const f_onsager::BigFloat = -2.10965114460820745966777928351108478082549327543540531781696107967700291143188081390114126499095041781
 
 function classical_ising_symmetric_3D(β)
-    x = cosh(β / 2)
-    y = sinh(β / 2)
+    x = cosh(β)
+    y = sinh(β)
     W = [sqrt(x) sqrt(y); sqrt(x) -sqrt(y)]
     T_array = zeros(Float64, 2, 2, 2, 2, 2, 2)
     for (i, j, k, l, m, n) in Iterators.product([1:2 for _ in 1:6]...)
@@ -47,8 +47,8 @@ function classical_ising_symmetric_3D(β)
     return permute(T, ((1, 4), (5, 6, 2, 3)))
 end
 
-function classical_ising_3D(; beta, J=1.0)
-    K = beta * J
+function classical_ising_3D(; β, J=1.0)
+    K = β * J
 
     # Boltzmann weights
     t = ComplexF64[exp(K) exp(-K); exp(-K) exp(K)]

--- a/src/models/ising.jl
+++ b/src/models/ising.jl
@@ -28,3 +28,20 @@ end
 classical_ising_symmetric() = classical_ising_symmetric(ising_βc)
 
 const f_onsager::BigFloat = -2.10965114460820745966777928351108478082549327543540531781696107967700291143188081390114126499095041781
+
+function classical_ising_symmetric_3D(β)
+    x = cosh(β / 2)
+    y = sinh(β / 2)
+    W = [sqrt(x) sqrt(y); sqrt(x) -sqrt(y)]
+    T_array = zeros(Float64, 2, 2, 2, 2, 2, 2)
+
+    for a in 1:2
+        # Outer product of W[a, :] with itself 6 times
+        T_array .+= W[a, :] ⊗ W[a, :] ⊗ W[a, :] ⊗ W[a, :] ⊗ W[a, :] ⊗ W[a, :]
+    end
+
+    S = ℤ₂Space(0 => 1, 1 => 1)
+    T = TensorMap(T_array, S ⊗ S ⊗ S ← S ⊗ S ⊗ S)
+
+    return T
+end

--- a/src/schemes/atrg3d.jl
+++ b/src/schemes/atrg3d.jl
@@ -80,4 +80,4 @@ function Base.show(io::IO, scheme::ATRG_3D)
     return nothing
 end
 
-ATRG_3D_convcrit(steps::Int, data) = abs(log(data[end]) * 2.0^(1 - steps))
+ATRG_3D_convcrit(steps::Int, data) = abs(log(data[end]) * 8.0^(1 - steps))

--- a/src/schemes/atrg3d.jl
+++ b/src/schemes/atrg3d.jl
@@ -1,4 +1,4 @@
-mutable struct ATRG_3D <: TRGScheme
+mutable struct ATRG_3D <: TNRScheme
     T::TensorMap
 
     finalize!::Function

--- a/src/schemes/atrg3d.jl
+++ b/src/schemes/atrg3d.jl
@@ -44,7 +44,7 @@ function step!(scheme::ATRG_3D, trunc::TensorKit.TruncationScheme)
     @tensor Proj_4[-1; -2 -3] := inv_s2[-1; 1] * adjoint(U2)[1; 2] * R3[2; -2 -3]
 
     @tensor H[-1 -2; -3 -4] := YD[-1 -2; 1 2 3 4] * Proj_3[1 2; -3] * Proj_1[3 4; -4]
-    @tensor G[-1 -2; -3 -4] := AX[-1 -2; 1 2 3 4] * Proj_4[1 2; -3] * Proj_2[3 4; -4]
+    @tensor G[-1 -2; -3 -4] := AX[-1 -2; 1 2 3 4] * Proj_4[-3; 1 2] * Proj_2[-4; 3 4]
 
     @tensor scheme.T[-1 -2; -3 -4 -5 -6] := G[1 -2; -5 -6] * H[-1 1; -3 -4]
     return scheme

--- a/src/schemes/atrg3d.jl
+++ b/src/schemes/atrg3d.jl
@@ -69,7 +69,7 @@ function finalize!(scheme::ATRG_3D)
     scheme.T /= n
 
     # turn the tensor by 90 degrees
-    scheme.T = permute(scheme.T, ((4, 6), (2, 5, 1, 3)))
+    #scheme.T = permute(scheme.T, ((4, 6), (2, 5, 1, 3)))
 
     return n
 end

--- a/src/schemes/atrg3d.jl
+++ b/src/schemes/atrg3d.jl
@@ -1,0 +1,63 @@
+mutable struct ATRG_3D <: TRGScheme
+    T::TensorMap
+
+    finalize!::Function
+    function ATRG_3D(T::TensorMap{E,S,2,4}; finalize=(finalize!)) where {E,S}
+        return new(T, finalize)
+    end
+end
+
+function step!(scheme::ATRG_3D, trunc::TensorKit.TruncationScheme)
+    U, S, V, _ = tsvd(scheme.T, ((2, 5, 6), (3, 4, 1)); trunc=trunc)
+    A = permute(U, ((4, 1), (2, 3)))
+    D = permute(V, ((4, 1), (2, 3)))
+    C = permute(U * S, ((4, 1), (2, 3)))
+    B = permute(S * V, ((4, 1), (2, 3)))
+
+    @tensor M[-1 -2; -3 -4 -5 -6] := B[1 -2; -3 -4] * C[-1 1; -5 -6]
+
+    U, S, V, _ = tsvd(M, ((2, 5, 6), (3, 4, 1)); trunc=trunc)
+    sqrtS = sqrt(S)
+
+    X = permute(U * sqrtS, ((4, 1), (2, 3)))
+    Y = permute(sqrtS * V, ((4, 1), (2, 3)))
+
+    @tensor AX[-1 -2; -3 -4 -5 -6] := A[1 -2; -3 -5] * X[-1 1; -4 -6]
+    @tensor YD[-1 -2; -3 -4 -5 -6] := Y[1 -2; -3 -5] * D[-1 1; -4 -6]
+
+    #The QR decompositions and construction of the four isometries
+    _, R1 = leftorth(YD, ((1, 2, 3, 4), (5, 6)))
+    R2, _ = rightorth(AX, ((5, 6), (1, 2, 3, 4)))
+    _, R3 = leftorth(YD, ((1, 2, 5, 6), (3, 4)))
+    R4, _ = rightorth(AX, ((3, 4), (1, 2, 5, 6)))
+
+    @tensor temp1[-1; -2] := R1[-1; 1 2] * R2[1 2; -2]
+    U1, S1, V1, _ = tsvd(temp1, (1,), (2,); trunc=trunc)
+    inv_s1 = pseudopow(S1, -0.5)
+    @tensor Proj_1[-1 -2; -3] := R2[-1 -2; 1] * adjoint(V1)[1; 2] * inv_s1[2; -3]
+    @tensor Proj_2[-1; -2 -3] := inv_s1[-1; 1] * adjoint(U1)[1; 2] * R1[2; -2 -3]
+
+    @tensor temp2[-1; -2] := R3[-1; 1 2] * R4[1 2; -2]
+    U2, S2, V2, _ = tsvd(temp2, (1,), (2,); trunc=trunc)
+    inv_s2 = pseudopow(S2, -0.5)
+    @tensor Proj_3[-1 -2; -3] := R4[-1 -2; 1] * adjoint(V2)[1; 2] * inv_s2[2; -3]
+    @tensor Proj_4[-1; -2 -3] := inv_s2[-1; 1] * adjoint(U2)[1; 2] * R3[2; -2 -3]
+
+    @tensor H[-1 -2; -3 -4] := YD[-1 -2; 1 2 3 4] * Proj_3[1 2; -3] * Proj_1[3 4; -4]
+    @tensor G[-1 -2; -3 -4] := AX[-1 -2; 1 2 3 4] * Proj_4[1 2; -3] * Proj_2[3 4; -4]
+
+    @tensor scheme.T[-1 -2; -3 -4 -5 -6] := G[1 -2; -5 -6] * H[-1 1; -3 -4]
+    return scheme
+end
+
+function finalize!(scheme::ATRG_3D)
+    n = norm(@tensor scheme.T[1 1; 2 3 2 3])
+    scheme.T /= n
+
+    # turn the tensor by 90 degrees
+    scheme.T = permute(scheme.T, ((4, 6), (2, 5, 1, 3)))
+
+    return n
+end
+
+ATRG_3D_convcrit(steps::Int, data) = abs(log(data[end]) * 2.0^(1 - steps))

--- a/test/ising.jl
+++ b/test/ising.jl
@@ -138,3 +138,21 @@ end
     relerror = abs((fs - f_onsager) / f_onsager)
     @test relerror < 1e-6
 end
+
+# ATRG_3D
+@testset "ATRG_3D - Ising Model" begin
+    T_3D = classical_ising_symmetric_3D()
+    scheme = ATRG_3D(T_3D)
+    data = run!(scheme, truncdim(12), maxiter(25))
+
+    lnz = 0
+    for (i, d) in enumerate(data)
+        lnz += log(d) * 8.0^(1 - i)
+    end
+
+    fs = lnz * -1 / ising_βc_3D
+    @show fs
+    f_benchmark = -3.515
+    relerror = abs((fs - f_benchmark) / f_benchmark)
+    @test relerror < 1e-3
+end


### PR DESCRIPTION
This PR implements Anisotropic TRG for 3D cubic lattice as per [PhysRevB.102.054432](https://journals.aps.org/prb/abstract/10.1103/PhysRevB.102.054432) . The free energy in the tests is computed by normalising the tensors after coarse graining in all three directions which seems unstable but looks like the most symmetric way of doing things. 