### PR TITLE
faster_initialization

### DIFF
--- a/src/schemes/looptnr.jl
+++ b/src/schemes/looptnr.jl
@@ -169,7 +169,7 @@ function Ψ_B(scheme::LoopTNR, trunc::TensorKit.TruncationScheme)
     end
 
     ΨB_function(steps, data) = abs(data[end])
-    criterion = maxiter(100) & convcrit(1e-12, ΨB_function)
+    criterion = maxiter(10) & convcrit(1e-12, ΨB_function)
     PR_list, PL_list = find_projectors(ΨB, criterion, trunc)
 
     ΨB_disentangled = []


### PR DESCRIPTION
I reduced the number of entanglement filtering steps in the course of the initialization of loop-opt. 
This allows for faster initialization.