### PR TITLE
Add `show` methods for `Stopcrit`s

### DIFF
--- a/src/schemes/ctm/c4ctm.jl
+++ b/src/schemes/ctm/c4ctm.jl
@@ -25,7 +25,7 @@ end
     │               │           
 =#
 
-function run!(scheme::c4CTM, trunc::TensorKit.TruncationScheme, criterion::stopcrit;
+function run!(scheme::c4CTM, trunc::TensorKit.TruncationScheme, criterion::Stopcrit;
               verbosity=1)
     LoggingExtras.withlevel(; verbosity) do
         @infov 1 "Starting simulation\n $(scheme)\n"

--- a/src/schemes/ctm/ctm_hotrg.jl
+++ b/src/schemes/ctm/ctm_hotrg.jl
@@ -106,7 +106,7 @@ end
 
 function run!(scheme::ctm_HOTRG,
               trunc::TensorKit.TruncationScheme,
-              criterion::stopcrit;
+              criterion::Stopcrit;
               sweep=30,
               return_cft=false,
               inv=false,

--- a/src/schemes/ctm/rctm.jl
+++ b/src/schemes/ctm/rctm.jl
@@ -74,7 +74,7 @@ end
 
 function run!(scheme::rCTM,
               trunc::TensorKit.TruncationScheme,
-              criterion::TNRKit.stopcrit;
+              criterion::TNRKit.Stopcrit;
               verbosity=1,)
     LoggingExtras.withlevel(; verbosity) do
         @infov 1 "Starting simulation\n $(scheme)\n"

--- a/src/schemes/looptnr.jl
+++ b/src/schemes/looptnr.jl
@@ -48,7 +48,7 @@ end
 
 #Functions to find the left and right projectors
 
-function find_L(pos::Int, psi::Array, entanglement_criterion::stopcrit)
+function find_L(pos::Int, psi::Array, entanglement_criterion::Stopcrit)
     L = id(space(psi[pos])[1])
     crit = true
     steps = 0
@@ -73,7 +73,7 @@ function find_L(pos::Int, psi::Array, entanglement_criterion::stopcrit)
     return L
 end
 
-function find_R(pos::Int, psi::Array, entanglement_criterion::stopcrit)
+function find_R(pos::Int, psi::Array, entanglement_criterion::Stopcrit)
     n = length(psi)
     if numin(psi[mod(pos - 2, n) + 1]) == 2
         R = id(space(psi[mod(pos - 2, n) + 1])[3]')
@@ -113,7 +113,7 @@ function P_decomp(R::TensorMap, L::TensorMap, trunc::TensorKit.TruncationScheme)
     return PR, PL
 end
 
-function find_projectors(psi::Array, entanglement_criterion::stopcrit,
+function find_projectors(psi::Array, entanglement_criterion::Stopcrit,
                          trunc::TensorKit.TruncationScheme)
     PR_list = []
     PL_list = []
@@ -206,7 +206,7 @@ entanglement_criterion = maxiter(100) & convcrit(1e-15, entanglement_function)
 
 loop_criterion = maxiter(50) & convcrit(1e-8, entanglement_function)
 
-function entanglement_filtering!(scheme::LoopTNR, entanglement_criterion::stopcrit,
+function entanglement_filtering!(scheme::LoopTNR, entanglement_criterion::Stopcrit,
                                  trunc::TensorKit.TruncationScheme)
     ΨA = Ψ_A(scheme)
     PR_list, PL_list = find_projectors(ΨA, entanglement_criterion, trunc)
@@ -341,7 +341,7 @@ function opt_T(N, W, psi)
     return new_T
 end
 
-function loop_opt!(scheme::LoopTNR, loop_criterion::stopcrit,
+function loop_opt!(scheme::LoopTNR, loop_criterion::Stopcrit,
                    trunc::TensorKit.TruncationScheme, verbosity::Int)
     psi_A = Ψ_A(scheme)
     psi_B = Ψ_B(scheme, trunc)
@@ -387,17 +387,17 @@ end
 
 function step!(scheme::LoopTNR, trunc::TensorKit.TruncationScheme,
                truncentanglement::TensorKit.TruncationScheme,
-               entanglement_criterion::stopcrit,
-               loop_criterion::stopcrit, verbosity::Int)
+               entanglement_criterion::Stopcrit,
+               loop_criterion::Stopcrit, verbosity::Int)
     entanglement_filtering!(scheme, entanglement_criterion, truncentanglement)
     loop_opt!(scheme, loop_criterion, trunc, verbosity::Int)
     return scheme
 end
 
 function run!(scheme::LoopTNR, trscheme::TensorKit.TruncationScheme,
-              truncentanglement::TensorKit.TruncationScheme, criterion::stopcrit,
-              entanglement_criterion::stopcrit,
-              loop_criterion::stopcrit;
+              truncentanglement::TensorKit.TruncationScheme, criterion::Stopcrit,
+              entanglement_criterion::Stopcrit,
+              loop_criterion::Stopcrit;
               finalize_beginning=true, verbosity=1)
     data = []
 
@@ -424,7 +424,7 @@ function run!(scheme::LoopTNR, trscheme::TensorKit.TruncationScheme,
     return data
 end
 
-function run!(scheme::LoopTNR, trscheme::TensorKit.TruncationScheme, criterion::stopcrit;
+function run!(scheme::LoopTNR, trscheme::TensorKit.TruncationScheme, criterion::Stopcrit;
               finalize_beginning=true, verbosity=1)
     return run!(scheme, trscheme, truncbelow(1e-15), criterion, entanglement_criterion,
                 loop_criterion;

--- a/src/schemes/symmetric_looptnr.jl
+++ b/src/schemes/symmetric_looptnr.jl
@@ -168,7 +168,7 @@ function step!(scheme, trunc, oneloop)
 end
 
 function run!(scheme::SLoopTNR, trscheme::TensorKit.TruncationScheme,
-              criterion::TNRKit.stopcrit; finalize_beginning=true, oneloop=true,
+              criterion::TNRKit.Stopcrit; finalize_beginning=true, oneloop=true,
               verbosity=1)
     data = []
 

--- a/src/schemes/tnrscheme.jl
+++ b/src/schemes/tnrscheme.jl
@@ -3,7 +3,7 @@ abstract type TNRScheme end
 function step! end
 function finalize! end
 
-function run!(scheme::TNRScheme, trscheme::TensorKit.TruncationScheme, criterion::stopcrit;
+function run!(scheme::TNRScheme, trscheme::TensorKit.TruncationScheme, criterion::Stopcrit;
               finalize_beginning=true, verbosity=1)
     data = []
 

--- a/src/utility/stopping.jl
+++ b/src/utility/stopping.jl
@@ -1,19 +1,19 @@
-abstract type stopcrit end
+abstract type Stopcrit end
 
-struct maxiter <: stopcrit
+struct maxiter <: Stopcrit
     n::Int
 end
 
-struct convcrit <: stopcrit
+struct convcrit <: Stopcrit
     Δ::Float64
     f::Function
 end
 
-struct MultipleCrit <: stopcrit
-    crits::Vector{stopcrit}
+struct MultipleCrit <: Stopcrit
+    crits::Vector{Stopcrit}
 end
 
-Base.:&(a::stopcrit, b::stopcrit) = MultipleCrit([a, b])
+Base.:&(a::Stopcrit, b::Stopcrit) = MultipleCrit([a, b])
 
 (crit::maxiter)(steps::Int, data) = steps < crit.n
 (crit::convcrit)(steps::Int, data) = crit.Δ < crit.f(steps, data)

--- a/src/utility/stopping.jl
+++ b/src/utility/stopping.jl
@@ -14,6 +14,9 @@ struct MultipleCrit <: Stopcrit
 end
 
 Base.:&(a::Stopcrit, b::Stopcrit) = MultipleCrit([a, b])
+Base.:&(a::Stopcrit, b::MultipleCrit) = MultipleCrit([a; b.crits])
+Base.:&(a::MultipleCrit, b::Stopcrit) = MultipleCrit([a.crits; b])
+Base.:&(a::MultipleCrit, b::MultipleCrit) = MultipleCrit([a.crits; b.crits])
 
 (crit::maxiter)(steps::Int, data) = steps < crit.n
 (crit::convcrit)(steps::Int, data) = crit.Δ < crit.f(steps, data)
@@ -39,3 +42,24 @@ function stopping_info(crit::convcrit, steps::Int, data)
 end
 
 trivial_convcrit(Δ) = convcrit(Δ, (steps, data) -> last(data))
+
+# === Show methods ===
+function Base.summary(crit::maxiter)
+    return "Maximum iterations: $(crit.n)"
+end
+
+function Base.show(io::IO, crit::Stopcrit)
+    println(io, "Stopping criterion")
+    print(io, "  * ", summary(crit))
+end
+
+function Base.show(io::IO, crit::MultipleCrit)
+    print(io, "Multiple stopping criteria")
+    for c in crit.crits
+        print(io, "\n  * ", summary(c))
+    end
+end
+
+function Base.summary(crit::convcrit)
+    return "Convergence criterion: $(crit.f) <= $(crit.Δ)"
+end


### PR DESCRIPTION
This PR implements 2 changes
- `stopcrit`s are now called `Stopcrit`s (capital S)
- `Stopcrit`s now have dedicated show methods