### PR TITLE
CFT data with charge sectors

### DIFF
--- a/src/TNRKit.jl
+++ b/src/TNRKit.jl
@@ -64,7 +64,7 @@ export classical_potts, classical_potts_symmetric, potts_βc
 
 # utility functions
 include("utility/cft.jl")
-export cft_data, central_charge
+export cft_data, central_charge, cft_data!
 
 include("utility/finalize.jl")
 export finalize!, finalize_two_by_two!, finalize_cftdata!, finalize_central_charge!

--- a/src/schemes/looptnr.jl
+++ b/src/schemes/looptnr.jl
@@ -368,7 +368,7 @@ end
 # Function to perform the optimization loop for the LoopTNR scheme. Sweeping from left to right, we optimize the tensors in the loop by minimizing the cost function.
 # Here cache of right-half-chain is used to minimize the number of multiplications to accelerate the sweeping. 
 # The transfer matrix on the left is updated after each optimization step.
-# The cache technique is from Chengfeng Bao's program, see http://hdl.handle.net/10012/14674
+# The cache technique is from Chengfeng Bao's program, see http://hdl.handle.net/10012/14674.
 function loop_opt!(scheme::LoopTNR, loop_criterion::stopcrit,
                    trunc::TensorKit.TruncationScheme,
                    truncentanglement::TensorKit.TruncationScheme, verbosity::Int)

--- a/src/schemes/looptnr.jl
+++ b/src/schemes/looptnr.jl
@@ -368,7 +368,7 @@ end
 # Function to perform the optimization loop for the LoopTNR scheme. Sweeping from left to right, we optimize the tensors in the loop by minimizing the cost function.
 # Here cache of right-half-chain is used to minimize the number of multiplications to accelerate the sweeping. 
 # The transfer matrix on the left is updated after each optimization step.
-# The cache technique is from Chengfeng Bao's program, see http://hdl.handle.net/10012/14674.
+# The cache technique is from Chenfeng Bao's thesis, see http://hdl.handle.net/10012/14674.
 function loop_opt!(scheme::LoopTNR, loop_criterion::stopcrit,
                    trunc::TensorKit.TruncationScheme,
                    truncentanglement::TensorKit.TruncationScheme, verbosity::Int)

--- a/src/schemes/looptnr.jl
+++ b/src/schemes/looptnr.jl
@@ -368,6 +368,7 @@ end
 # Function to perform the optimization loop for the LoopTNR scheme. Sweeping from left to right, we optimize the tensors in the loop by minimizing the cost function.
 # Here cache of right-half-chain is used to minimize the number of multiplications to accelerate the sweeping. 
 # The transfer matrix on the left is updated after each optimization step.
+# The cache technique is from Chengfeng Bao's program, see http://hdl.handle.net/10012/14674
 function loop_opt!(scheme::LoopTNR, loop_criterion::stopcrit,
                    trunc::TensorKit.TruncationScheme,
                    truncentanglement::TensorKit.TruncationScheme, verbosity::Int)

--- a/src/utility/cft.jl
+++ b/src/utility/cft.jl
@@ -89,17 +89,7 @@ function shape_factor_2x2(A, B; is_real=true)
     end
 end
 
-# Computing the conformal spectrum via charge insertion
-#      |
-#      v
-#  ----|--<---
-# | ---|-->-- |
-# || xxxxxx  ||
-#  \-  \ / \ /^
-#   \   B   B |
-#    \ / \ / \|
-#     A   A  
-#    / \ / \
+# Fig.25 of https://arxiv.org/pdf/2311.18785
 function spec_2x4(A, B; Nh=10, is_real=true)
     I = sectortype(A)
     if BraidingStyle(I) != Bosonic()

--- a/src/utility/cft.jl
+++ b/src/utility/cft.jl
@@ -89,7 +89,7 @@ function shape_factor_2x2(A, B; is_real=true)
     end
 end
 
-# Fig.25 of https://arxiv.org/pdf/2311.18785
+# Fig.25 of https://arxiv.org/pdf/2311.18785. Firstly appear in Chengfeng Bao's paper, see http://hdl.handle.net/10012/14674.
 function spec_2x4(A, B; Nh=10, is_real=true)
     I = sectortype(A)
     if BraidingStyle(I) != Bosonic()

--- a/src/utility/cft.jl
+++ b/src/utility/cft.jl
@@ -112,17 +112,22 @@ function spec_2x4(A, B; Nh=10, is_real=true)
     for charge in values(I)
         V = Vect[I](charge=>1)
         x = rand(domain(B)⊗domain(B)←V)
-        function f(x)
-            @tensor fx[-1 -2 -3 -4; 5] := B[-1 -2; 1 2] * x[1 2 3 4; 5] * B[-3 -4; 3 4]
-            @tensor ffx[-1 -2 -3 -4; 5] := A[-3 -4; 2 3] * fx[1 2 3 4; 5] * A[-1 -2; 4 1]
-            return permute(ffx, (2, 3, 4, 1), (5,))
-        end
-        spec, _, _ = eigsolve(f, x, Nh, :LR; krylovdim=40, maxiter=100, tol=1e-12,
-                              verbosity=0)
-        if is_real
-            spec_sector[charge] = filter(x->abs(x)≥1e-12, real.(spec))
+        if dim(x) == 0
+            spec_sector[charge] = [0.0]
         else
-            spec_sector[charge] = filter(x->abs(real(x))≥1e-12, spec)
+            function f(x)
+                @tensor fx[-1 -2 -3 -4; 5] := B[-1 -2; 1 2] * x[1 2 3 4; 5] * B[-3 -4; 3 4]
+                @tensor ffx[-1 -2 -3 -4; 5] := A[-3 -4; 2 3] * fx[1 2 3 4; 5] *
+                                               A[-1 -2; 4 1]
+                return permute(ffx, (2, 3, 4, 1), (5,))
+            end
+            spec, _, _ = eigsolve(f, x, Nh, :LR; krylovdim=40, maxiter=100, tol=1e-12,
+                                  verbosity=0)
+            if is_real
+                spec_sector[charge] = filter(x->abs(x)≥1e-12, real.(spec))
+            else
+                spec_sector[charge] = filter(x->abs(real(x))≥1e-12, spec)
+            end
         end
     end
 

--- a/src/utility/cft.jl
+++ b/src/utility/cft.jl
@@ -89,7 +89,7 @@ function shape_factor_2x2(A, B; is_real=true)
     end
 end
 
-# Fig.25 of https://arxiv.org/pdf/2311.18785. Firstly appear in Chengfeng Bao's paper, see http://hdl.handle.net/10012/14674.
+# Fig.25 of https://arxiv.org/pdf/2311.18785. Firstly appear in Chenfeng Bao's thesis, see http://hdl.handle.net/10012/14674.
 function spec_2x4(A, B; Nh=10, is_real=true)
     I = sectortype(A)
     if BraidingStyle(I) != Bosonic()

--- a/src/utility/cft.jl
+++ b/src/utility/cft.jl
@@ -121,7 +121,7 @@ function spec_2x4(A, B; Nh=10, is_real=true)
                                                A[-1 -2; 4 1]
                 return permute(ffx, (2, 3, 4, 1), (5,))
             end
-            spec, _, _ = eigsolve(f, x, Nh, :LR; krylovdim=40, maxiter=100, tol=1e-12,
+            spec, _, _ = eigsolve(f, x, Nh, :LM; krylovdim=40, maxiter=100, tol=1e-12,
                                   verbosity=0)
             if is_real
                 spec_sector[charge] = filter(x->abs(x)≥1e-12, real.(spec))

--- a/src/utility/cft.jl
+++ b/src/utility/cft.jl
@@ -68,24 +68,70 @@ function cft_data(scheme::BTRG; v=1, unitcell=1, is_real=true)
     return unitcell * (1 / (2π * v)) * log.(data[1] ./ data)
 end
 
-function cft_data(scheme::LoopTNR; is_real=true)
-    @tensor opt = true T[-1 -2; -3 -4] := scheme.TA[-1 1; 3 2] * scheme.TB[2 6; 4 -3] *
-                                          scheme.TB[-2 3; 1 5] * scheme.TA[5 4; 6 -4]
+# Function to obtain the "canonical" normalization constant
+function shape_factor_2x2(A, B)
+    a_in = domain(A)[1]
+    b_in = domain(B)[1]
+    x0 = rand(a_in ⊗ b_in)
 
-    D, V = eig(T)
-    diag = []
-    for (i, d) in blocks(D)
-        push!(diag, d...)
+    function f0(x)
+        @planar fx[-1 -2] := A[c -1; 1 m] * x[1 2] * B[m -2; 2 c]
+        @planar ffx[-1 -2] := B[c -1; 1 m] * fx[1 2] * A[m -2; 2 c]
+        return ffx
     end
-    diag = filter(x -> abs(x) > 1e-12, diag)
-    data = sort!(diag; by=x -> abs(x), rev=true)
 
-    if is_real
-        data = real(data)
-        return (1 / (2π)) * log.(abs.(data[1] ./ data))
-    else
-        return (1 / (2π)) * log.(data[1] ./ data)
+    spec0, _, _ = eigsolve(f0, x0, 1, :LR; verbosity=0)
+
+    return abs(spec0[1])
+end
+
+# Computing the conformal spectrum via charge insertion
+#      |
+#      v
+#  ----|--<---
+# | ---|-->-- |
+# || xxxxxx  ||
+#  \-  \ / \ /^
+#   \   B   B |
+#    \ / \ / \|
+#     A   A  
+#    / \ / \
+function spec_2x4(A, B; Nh=10)
+    I = sectortype(A)
+    if BraidingStyle(I) != Bosonic()
+        throw(ArgumentError("Sectors with non-Bosonic charge $I has not been implemented"))
     end
+
+    spec_sector = Dict()
+    conformal_data = Dict()
+
+    for charge in values(I)
+        V = Vect[I](charge=>1)
+        x = rand(domain(B)⊗domain(B)←V)
+        function f(x)
+            @tensor fx[-1 -2 -3 -4; 5] := B[-1 -2; 1 2] * x[1 2 3 4; 5] * B[-3 -4; 3 4]
+            @tensor ffx[-1 -2 -3 -4; 5] := A[-3 -4; 2 3] * fx[1 2 3 4; 5] * A[-1 -2; 4 1]
+            return permute(ffx, (2, 3, 4, 1), (5,))
+        end
+        spec, _, _ = eigsolve(f, x, Nh, :LR; verbosity=0)
+        spec_sector[charge] = abs.(spec)
+    end
+
+    norm_const_0 = spec_sector[one(I)][1]
+    conformal_data["c"] = -12/pi*log(norm_const_0)
+    for irr_center in values(I)
+        conformal_data[irr_center] = - 1/pi * log.(spec_sector[irr_center]/norm_const_0)
+    end
+    return conformal_data
+end
+
+# The function to obtain central charge and conformal spectrum from the fixed-point tensor with G-symmetry. Here the conformal spectrum is obtained by different charge sectors.
+function cft_data!(scheme::LoopTNR)
+    norm_const = shape_factor_2x2(scheme.TA, scheme.TB)
+    scheme.TA = scheme.TA/norm_const^(1/4)
+    scheme.TB = scheme.TB/norm_const^(1/4)
+    conformal_data = spec_2x4(scheme.TA, scheme.TB)
+    return conformal_data
 end
 
 """


### PR DESCRIPTION
Hi I added the CFT data with charge sectors.

1. Uses Krylov method to compute CFT spectrum. Here conformal spectrums are classified by sectors of charges;
2. Compute the central charge and scaling dimensions in one function, and stored in a dictionary;
3. Uses the 2*4 transfer matrix.

Please give comments!