### PR TITLE
blocking_initial_tensors

### DIFF
--- a/src/TNRKit.jl
+++ b/src/TNRKit.jl
@@ -71,4 +71,7 @@ export finalize!, finalize_two_by_two!, finalize_cftdata!, finalize_central_char
 
 include("utility/cdl.jl")
 export cdl_tensor
+
+include("utility/blocking.jl")
+export block_tensors
 end

--- a/src/utility/blocking.jl
+++ b/src/utility/blocking.jl
@@ -1,0 +1,17 @@
+function block_tensors(O_list::Matrix)
+    m, n = size(O_list)
+    ind_list = [[(n+1)*(i-1)+j, m*(n+1)+(m+1)*(j-1)+i+1, m*(n+1)+(m+1)*(j-1)+i,
+                 (n+1)*(i-1)+j+1] for i in 1:m for j in 1:n]
+    Vv = [space(O_list[end, j])[2] for j in 1:n]
+    Uv = isomorphism(fuse(Vv...), prod(Vv))
+    Vh = [space(O_list[i, 1])[1] for i in 1:m]
+    Uh = isomorphism(fuse(Vh...), prod(Vh))
+
+    ind1 = vcat(-1, [(n+1)*(i-1)+1 for i in 1:m])
+    ind2 = vcat(-2, [m*(n+1) + (m+1)*j for j in 1:n])
+    ind3 = vcat([m*(n+1) + (m+1)*(j-1) + 1 for j in 1:n], -3)
+    ind4 = vcat([(n+1)*i for i in 1:m], -4)
+    tensors = vcat(O_list[:], [Uh, Uv, adjoint(Uv), adjoint(Uh)])
+    inds = vcat(ind_list, [ind1, ind2, ind3, ind4])
+    return permute(ncon(tensors, inds), (1, 2), (3, 4))
+end

--- a/src/utility/cft.jl
+++ b/src/utility/cft.jl
@@ -1,3 +1,7 @@
+function next_τ(τ)
+    return (τ-1)/(τ+1)
+end
+
 function cft_data(scheme::TNRScheme; v=1, unitcell=1, is_real=true)
     # make the indices
     indices = [[i, -i, -(i + unitcell), i + 1] for i in 1:unitcell]


### PR DESCRIPTION
Implementation of blocking  m x n initial tensors into a single one.
This allows to compute stat-mech models with larger unit-cells and cft with various geometry.

Contraction order is not optimal, but should be fine as long as m and n are small.