### PR TITLE
A method to compute the conformal spin up to 6

### DIFF
--- a/src/TNRKit.jl
+++ b/src/TNRKit.jl
@@ -68,7 +68,7 @@ export classical_clock
 
 # utility functions
 include("utility/cft.jl")
-export cft_data, central_charge, cft_data!
+export cft_data, central_charge, cft_data!, cft_data_spin!
 
 include("utility/finalize.jl")
 export finalize!, finalize_two_by_two!, finalize_cftdata!, finalize_central_charge!


### PR DESCRIPTION
Hi @VictorVanthilt  and @dartsushi,

I made some modifications of Loop-TNR and added an approach to calculate the conformal spin with the ambiguity of 6. This is based on some discussions with Yingjie Wei, my previous group-mate, and @dartsushi.

The modifications include

1. Added more QR functions, such that they can be used to compress the quantum model along the temperature direction in the future
2. Added a method to calculate the conformal spin up to 6. That is, spins from -3 to 3 can be determined without ambiguity. Some graphical illustrations can be found in [the note](https://github.com/Chenqitrg/CFT-notes/blob/main/transfer%20matrix.pdf).

The example of usage is the following:
```
using TensorKit, TensorKitSectors, TNRKit

Dcut = 16
NRG = 20
Nloop = 20

T = classical_ising_symmetric()
cftdata_spin(scheme::LoopTNR) = cft_data_spin!(scheme, truncdim(2*Dcut))
scheme = LoopTNR(T; finalize = cftdata_spin)

entanglement_function(steps, data) = abs(data[end])
entanglement_criterion = maxiter(100) & convcrit(1e-15, entanglement_function)
loop_criterion = maxiter(Nloop) & convcrit(1e-10, entanglement_function)

data = run!(
    scheme,
    truncdim(Dcut),
    truncbelow(1e-12),
    maxiter(NRG),
    entanglement_criterion,
    loop_criterion,
    verbosity = 3,
)
```
Note that the truncation dimension of the `cft_data_spin!` can be taken to be larger than that in Loop-TNR  to produce more precise scaling dimensions. The scaling dimensions and conformal spins correspond to the real part and the imaginary part of the spectrum respectively.

This is not necessarily the final realization of the spin function. Let's discuss it.

