### PR TITLE
`normalize!`

### DIFF
--- a/src/schemes/ctm/c4vctm.jl
+++ b/src/schemes/ctm/c4vctm.jl
@@ -122,8 +122,8 @@ function step!(scheme::c4vCTM, trunc)
         U[3 4; -3] *
         conj(U[1 2; -1])
 
-    scheme.C /= norm(scheme.C)
-    scheme.E /= norm(scheme.E)
+    normalize!(scheme.C)
+    normalize!(scheme.E)
     return S
 end
 

--- a/src/schemes/ctm/ctm_hotrg.jl
+++ b/src/schemes/ctm/ctm_hotrg.jl
@@ -102,8 +102,8 @@ function step!(
 
     tr_norm = tr_tensor(scheme.T; inv = inv)
     scheme.T /= tr_norm
-    scheme.E1 /= norm(scheme.E1)
-    scheme.E2 /= norm(scheme.E2)
+    normalize!(scheme.E1)
+    normalize!(scheme.E2)
     for _ in 0:sweep
         rctm_step!(scheme)
     end

--- a/src/schemes/ctm/ctm_trg.jl
+++ b/src/schemes/ctm/ctm_trg.jl
@@ -135,8 +135,8 @@ function step!(
 
     tr_norm = tr_tensor(scheme.T; inv = inv)
     scheme.T /= tr_norm
-    scheme.E1 /= norm(scheme.E1)
-    scheme.E2 /= norm(scheme.E2)
+    normalize!(scheme.E1)
+    normalize!(scheme.E2)
     for _ in 0:sweep
         rctm_step!(scheme)
     end

--- a/src/schemes/ctm/onesite_ctm.jl
+++ b/src/schemes/ctm/onesite_ctm.jl
@@ -71,16 +71,16 @@ function CTM_init(T; bc = ones, bc_free = false)
     return C, C, C, C, El, Eb, Et, Er
 end
 
-function normalize!(ctm::CTM)
-    ctm.Ctl /= norm(ctm.Ctl)
-    ctm.Ctr /= norm(ctm.Ctr)
-    ctm.Cbr /= norm(ctm.Cbr)
-    ctm.Cbl /= norm(ctm.Cbl)
-    ctm.Et /= norm(ctm.Et)
-    ctm.Er /= norm(ctm.Er)
-    ctm.Eb /= norm(ctm.Eb)
-    ctm.El /= norm(ctm.El)
-    return nothing
+function LinearAlgebra.normalize!(ctm::CTM)
+    normalize!(ctm.Ctl)
+    normalize!(ctm.Ctr)
+    normalize!(ctm.Cbr)
+    normalize!(ctm.Cbl)
+    normalize!(ctm.Et)
+    normalize!(ctm.Er)
+    normalize!(ctm.Eb)
+    normalize!(ctm.El)
+    return ctm
 end
 
 """

--- a/src/schemes/ctm/rctm.jl
+++ b/src/schemes/ctm/rctm.jl
@@ -62,9 +62,9 @@ function step!(scheme::rCTM, trunc)
     @tensor opt = true scheme.E2[-1 -2; -3] := scheme.E2[1 5; 3] * scheme.T[-2 4; 2 5] *
         conj(Vt[-3; 3 4]) * Vt[-1; 1 2]
 
-    scheme.C2 /= norm(scheme.C2)
-    scheme.E1 /= norm(scheme.E1)
-    scheme.E2 /= norm(scheme.E2)
+    normalize!(scheme.C2)
+    normalize!(scheme.E1)
+    normalize!(scheme.E2)
     # symmetrization of the edges to avoid the breaking of reflection due to the numerical error
     scheme.E1 = (scheme.E1 + flip(permute(scheme.E1, ((3, 2), (1,))), (1, 3)) / 2)
     scheme.E2 = (scheme.E2 + flip(permute(scheme.E1, ((3, 2), (1,))), (1, 3)) / 2)

--- a/src/schemes/ctm/sublattice_ctm.jl
+++ b/src/schemes/ctm/sublattice_ctm.jl
@@ -94,26 +94,26 @@ function CTM_init(TA, TB; bc = ones, bc_free = false)
     return C, C, C, C, C, C, C, C, ElA, ElB, EbA, EbB, ErA, ErB, EtA, EtB
 end
 
-function normalize!(ctm::Sublattice_CTM)
-    ctm.Ctl1 /= norm(ctm.Ctl1)
-    ctm.Ctr1 /= norm(ctm.Ctr1)
-    ctm.Cbr1 /= norm(ctm.Cbr1)
-    ctm.Cbl1 /= norm(ctm.Cbl1)
+function LinearAlgebra.normalize!(ctm::Sublattice_CTM)
+    normalize!(ctm.Ctl1)
+    normalize!(ctm.Ctr1)
+    normalize!(ctm.Cbr1)
+    normalize!(ctm.Cbl1)
 
-    ctm.Ctl2 /= norm(ctm.Ctl2)
-    ctm.Ctr2 /= norm(ctm.Ctr2)
-    ctm.Cbr2 /= norm(ctm.Cbr2)
-    ctm.Cbl2 /= norm(ctm.Cbl2)
+    normalize!(ctm.Ctl2)
+    normalize!(ctm.Ctr2)
+    normalize!(ctm.Cbr2)
+    normalize!(ctm.Cbl2)
 
-    ctm.EtA /= norm(ctm.EtA)
-    ctm.ErA /= norm(ctm.ErA)
-    ctm.EbA /= norm(ctm.EbA)
-    ctm.ElA /= norm(ctm.ElA)
-    ctm.EtB /= norm(ctm.EtB)
-    ctm.ErB /= norm(ctm.ErB)
-    ctm.EbB /= norm(ctm.EbB)
-    ctm.ElB /= norm(ctm.ElB)
-    return nothing
+    normalize!(ctm.EtA)
+    normalize!(ctm.ErA)
+    normalize!(ctm.EbA)
+    normalize!(ctm.ElA)
+    normalize!(ctm.EtB)
+    normalize!(ctm.ErB)
+    normalize!(ctm.EbB)
+    normalize!(ctm.ElB)
+    return ctm
 end
 
 function corner_spectrum(ctm::Sublattice_CTM)

--- a/src/schemes/ctm/utility.jl
+++ b/src/schemes/ctm/utility.jl
@@ -57,8 +57,8 @@ function rctm_step!(scheme; trunc = truncdim(dim(space(scheme.C2, 1))))
         U[3 4; -3] * conj(U[1 2; -1])
     @tensor opt = true scheme.E2[-1 -2; -3] := scheme.E2[1 5; 3] * scheme.T[-2 4; 2 5] *
         conj(Vt[-3; 3 4]) * Vt[-1; 1 2]
-    scheme.C2 /= norm(scheme.C2)
-    scheme.E1 /= norm(scheme.E1)
-    scheme.E2 /= norm(scheme.E2)
+    normalize!(scheme.C2)
+    normalize!(scheme.E1)
+    normalize!(scheme.E2)
     return S
 end

--- a/src/utility/projectors.jl
+++ b/src/utility/projectors.jl
@@ -18,7 +18,7 @@ function QR_L(
     )
     LT = transpose(L * transpose(T, permT), permLT)
     _, Rt = leftorth(LT)
-    return Rt / norm(Rt, Inf)
+    return normalize!(Rt, Inf)
 end
 
 function QR_R(
@@ -40,7 +40,7 @@ function QR_R(
     )
     TR = transpose(transpose(T, permT) * R, permTR)
     Lt, _ = rightorth(TR)
-    return Lt / norm(Lt, Inf)
+    return normalize!(Lt, Inf)
 end
 
 # Functions to find the left and right projectors


### PR DESCRIPTION
Small utility changes that uses `LinearAlgebra.normalize!` instead of the manual normalization.
Avoids some allocations as well.