### PR TITLE
declare globals as const

### DIFF
--- a/src/schemes/tnrscheme.jl
+++ b/src/schemes/tnrscheme.jl
@@ -23,9 +23,9 @@ end
 
 output_type(finalizer::Finalizer{E}) where {E} = E
 
-default_Finalizer = Finalizer(finalize!, Float64)
-ImpurityTRG_Finalizer = Finalizer(finalize!, Tuple{Float64, Float64})
-ImpurityHOTRG_Finalizer = Finalizer(finalize!, Tuple{Float64, Float64, Float64, Float64})
+const default_Finalizer = Finalizer(finalize!, Float64)
+const ImpurityTRG_Finalizer = Finalizer(finalize!, Tuple{Float64, Float64})
+const ImpurityHOTRG_Finalizer = Finalizer(finalize!, Tuple{Float64, Float64, Float64, Float64})
 
 # Finalization functions for the various TNR schemes
 abstract type TNRScheme{E, S} end


### PR DESCRIPTION
This avoids the type instability associated to non-const globals for every run that uses a default finalizer