### PR TITLE
Use `svd_compact` instead of `svd_full`

### DIFF
--- a/src/models/phi4_complex.jl
+++ b/src/models/phi4_complex.jl
@@ -89,7 +89,7 @@ function phi4_complex(K::Integer, μ0::Float64, λ::Float64)
     f = fmatrix_complex(ys, μ0, λ)
 
     # SVD fmatrix
-    U, S, V = svd_full!(f)
+    U, S, V = svd_compact!(f)
 
     N = K^2
     T_arr = zeros(eltype(S), N, N, N, N)
@@ -155,7 +155,7 @@ function phi4_complex_impϕ(K::Integer, μ0::Float64, λ::Float64)
     f = fmatrix_complex(ys, μ0, λ)
 
     # SVD fmatrix
-    U, S, V = svd_full!(f)
+    U, S, V = svd_compact!(f)
 
     N = K^2
     T_arr = zeros(ComplexF64, N, N, N, N)
@@ -222,7 +222,7 @@ function phi4_complex_impϕdag(K::Integer, μ0::Float64, λ::Float64)
     f = fmatrix_complex(ys, μ0, λ)
 
     # SVD fmatrix
-    U, S, V = svd_full!(f)
+    U, S, V = svd_compact!(f)
 
     N = K^2
     T_arr = zeros(ComplexF64, N, N, N, N)
@@ -288,7 +288,7 @@ function phi4_complex_impϕabs(K::Integer, μ0::Float64, λ::Float64)
     f = fmatrix_complex(ys, μ0, λ)
 
     # SVD fmatrix
-    U, S, V = svd_full!(f)
+    U, S, V = svd_compact!(f)
 
     N = K^2
     T_arr = zeros(ComplexF64, N, N, N, N)
@@ -354,7 +354,7 @@ function phi4_complex_impϕ2(K::Integer, μ0::Float64, λ::Float64)
     f = fmatrix_complex(ys, μ0, λ)
 
     # SVD fmatrix
-    U, S, V = svd_full!(f)
+    U, S, V = svd_compact!(f)
 
     N = K^2
     T_arr = zeros(ComplexF64, N, N, N, N)
@@ -421,7 +421,7 @@ function phi4_complex_all(K::Integer, μ0::Float64, λ::Float64)
     f = fmatrix_complex(ys, μ0, λ)
 
     # SVD fmatrix
-    U, S, V = svd_full!(f)
+    U, S, V = svd_compact!(f)
 
     N = K^2
 

--- a/src/models/phi4_real.jl
+++ b/src/models/phi4_real.jl
@@ -72,7 +72,7 @@ function phi4_real(K::Integer, μ0::Float64, λ::Float64, h::Float64 = 0.0)
     f = fmatrix_real(ys, μ0, λ, h)
 
     # SVD fmatrix
-    U, S, V = svd_full!(f)
+    U, S, V = svd_compact!(f)
 
     # Make tensor for one site
     T_arr = [
@@ -124,7 +124,7 @@ function phi4_real_imp1(K::Integer, μ0::Float64, λ::Float64, h::Float64 = 0.0)
     f = fmatrix_real(ys, μ0, λ, h)
 
     # SVD fmatrix
-    U, S, V = svd_full!(f)
+    U, S, V = svd_compact!(f)
 
     # Make tensor for one site
     T_arr = [
@@ -176,7 +176,7 @@ function phi4_real_imp2(K::Integer, μ0::Float64, λ::Float64, h::Float64 = 0.0)
     f = fmatrix_real(ys, μ0, λ, h)
 
     # SVD fmatrix
-    U, S, V = svd_full!(f)
+    U, S, V = svd_compact!(f)
 
     # Make tensor for one site
     T_arr = [

--- a/src/utility/cdl.jl
+++ b/src/utility/cdl.jl
@@ -9,7 +9,7 @@ function cdl_tensor(χ::Int; χcdl = 2)
         C[10; 9] * U[1 2 3; -1] * U[4 5 6; -2] *
         conj(U[7 8 9; -3]) * conj(U[10 11 12; -4])
     # random rotation
-    U, _, Vt = svd_full(randn(ℂ^(2 * χcdl + χ) ← ℂ^(2 * χcdl + χ)))
+    U, _, Vt = svd_compact(randn(ℂ^(2 * χcdl + χ) ← ℂ^(2 * χcdl + χ)))
     @tensoropt Anew[-1 -2; -3 -4] := Anew[1 2; 3 4] * U[1; -1] * conj(U[4; -4]) *
         Vt[2; -2] * conj(Vt[3; -3])
     return Anew

--- a/src/utility/cft.jl
+++ b/src/utility/cft.jl
@@ -255,7 +255,7 @@ Get the central charge given the current state of a `TNRScheme` and the previous
 """
 function central_charge(scheme::TNRScheme, n::Number)
     @tensor M[-1; -2] := (scheme.T / n)[1 -1; -2 1]
-    _, S, _ = svd_full(M)
+    _, S, _ = svd_compact(M)
     return log(S.data[1]) * 6 / (π)
 end
 
@@ -264,7 +264,7 @@ function central_charge(scheme::BTRG, n::Number)
         (scheme.T)[1 -1; 3 2] * scheme.S1[3; -2] *
             scheme.S2[2; 1]
     ) / n
-    _, S, _ = svd_full(M)
+    _, S, _ = svd_compact(M)
     return log(S.data[1]) * 6 / (π)
 end
 


### PR DESCRIPTION
As per suggestion from @lkdvos. `svd_compact` returns smaller objects if the map is rectangular.