### PR TITLE
Fix twist and use eigh_trunc in 3D HOTRG

### DIFF
--- a/src/schemes/hotrg3d.jl
+++ b/src/schemes/hotrg3d.jl
@@ -45,43 +45,64 @@ function twistnondual(t::AbstractTensorMap, is)
     return twist(t, is′)
 end
 
-function _get_hotrg3d_xproj(
-        A1::AbstractTensorMap{E, S, 2, 4}, A2::AbstractTensorMap{E, S, 2, 4},
-        trunc::TruncationStrategy; _check_twist::Bool = false
+function _get_MMdag_3d(
+        A1::AbstractTensorMap{E, S, 2, 4}, A2::AbstractTensorMap{E, S, 2, 4}
     ) where {E, S}
-    # join in z-direction, keep x-indices open (A1 below A2)
-    # left unitary
     A2′ = twistnondual(A2, [2, 3, 4, 5])
     A1′ = twistnondual(A1, [1, 3, 4, 5])
     @tensoropt MM[x2 z z′ x2′] :=
         A2[z z2; Y2 X2 y2 x2] * conj(A2′[z′ z2; Y2 X2 y2 x2′])
     @tensoropt MM[x1 x2; x1′ x2′] := MM[x2 z z′ x2′] *
         A1[z1 z; Y1 X1 y1 x1] * conj(A1′[z1 z′; Y1 X1 y1 x1′])
-    d, U, ε = eigh_trunc!(project_hermitian!(MM); trunc)
-    # check if twists are applied correctly
-    if _check_twist
-        @assert minimum(d.data) >= 0
+    for ax in 1:numout(MM)
+        @assert !isdual(codomain(MM, ax))
     end
-    # right unitary
+    for ax in 1:numin(MM)
+        @assert !isdual(domain(MM, ax))
+    end
+    project_hermitian!(MM)
+    return MM
+end
+
+function _get_MdagM_3d(
+        A1::AbstractTensorMap{E, S, 2, 4}, A2::AbstractTensorMap{E, S, 2, 4}
+    ) where {E, S}
     A2′ = twistdual(A2, [2, 3, 5, 6])
     A1′ = twistdual(A1, [1, 3, 5, 6])
     @tensoropt MM[x2 z z′ x2′] :=
         conj(A2[z z2; Y2 x2 y2 X2]) * A2′[z′ z2; Y2 x2′ y2 X2]
     @tensoropt MM[x1 x2; x1′ x2′] := MM[x2 z z′ x2′] *
         conj(A1[z1 z; Y1 x1 y1 X1]) * A1′[z1 z′; Y1 x1′ y1 X1]
-    d′, U′, ε′ = eigh_trunc!(project_hermitian!(MM); trunc)
-    if _check_twist
-        @assert minimum(d′.data) >= 0
+    for ax in 1:numout(MM)
+        @assert !isdual(codomain(MM, ax))
     end
+    for ax in 1:numin(MM)
+        @assert !isdual(domain(MM, ax))
+    end
+    project_hermitian!(MM)
+    return MM
+end
+
+function _get_hotrg3d_xproj(
+        A1::AbstractTensorMap{E, S, 2, 4}, A2::AbstractTensorMap{E, S, 2, 4},
+        trunc::TruncationStrategy
+    ) where {E, S}
+    # join in z-direction, keep x-indices open (A1 below A2)
+    # left unitary
+    MM = _get_MMdag_3d(A1, A2)
+    _, U, ε = eigh_trunc!(MM; trunc)
+    # right unitary
+    MM = _get_MdagM_3d(A1, A2)
+    _, U′, ε′ = eigh_trunc!(MM; trunc)
     return (ε > ε′) ? (U′, ε′) : (U, ε)
 end
 
 function _get_hotrg3d_yproj(
         A1::AbstractTensorMap{E, S, 2, 4}, A2::AbstractTensorMap{E, S, 2, 4},
-        trunc::TruncationStrategy; _check_twist::Bool = false
+        trunc::TruncationStrategy
     ) where {E, S}
     perm = ((1, 2), (4, 3, 6, 5))
-    return _get_hotrg3d_xproj(permute(A1, perm), permute(A2, perm), trunc; _check_twist)
+    return _get_hotrg3d_xproj(permute(A1, perm), permute(A2, perm), trunc)
 end
 
 function _step_hotrg3d(

--- a/test/schemes.jl
+++ b/test/schemes.jl
@@ -315,9 +315,10 @@ end
         Aspace = (Vphy ⊗ Vphy' ← Vvir ⊗ Vvir ⊗ Vvir' ⊗ Vvir')
         A1 = randn(ComplexF64, Aspace)
         A2 = randn(ComplexF64, Aspace)
-        U, ϵ = TNRKit._get_hotrg3d_xproj(A1, A2, notrunc(); _check_twist = true)
+        for MM in [TNRKit._get_MMdag_3d(A1, A2), TNRKit._get_MdagM_3d(A1, A2)]
+            @test isposdef(MM)
+        end
     end
-    @test true # just check the test can run through
 end
 
 # ImpurityHOTRG


### PR DESCRIPTION
This PR follows the updated 2D HOTRG to switch from `svd_trunc` to `eigh_trunc` in 3D HOTRG. The wrong twists for fermions there are also fixed.