### PR TITLE
Small Improvement Complex phi4 model

### DIFF
--- a/src/models/phi4_complex.jl
+++ b/src/models/phi4_complex.jl
@@ -117,12 +117,7 @@ end
 """
 $(SIGNATURES)
 
-Constructs the partition function tensor for a 2D square lattice
-<<<<<<< SmallImprovementComplexPhi4
-for the complex ϕ^4 model with a given approximation `K`, bare mass µ_0^2 `μ0` and interaction constant `λ`.
-=======
-for the complex ϕ^4 model with a given approximation (and bond dimension) `K`, bare mass ``µ_0^2`` `μ0`, interaction constant `λ` and external field `h`.
->>>>>>> master
+Constructs the partition function tensor for a 2D square lattice for the complex ϕ^4 model with a given approximation `K`, bare mass µ_0^2 `μ0` and interaction constant `λ`.
 
 It is based on [Gauss-Hermite quadrature](https://en.wikipedia.org/wiki/Gauss%E2%80%93Hermite_quadrature).
 
@@ -188,12 +183,7 @@ end
 """
 $(SIGNATURES)
 
-Constructs the impurity tensor for a 2D square lattice
-<<<<<<< SmallImprovementComplexPhi4
-for the complex ϕ^4 model with a given approximation `K`, bare mass µ_0^2 `μ0` and interaction constant `λ`.
-=======
-for the complex ϕ^4 model with a given approximation (and bond dimension) `K`, bare mass ``µ_0^2`` `μ0`, interaction constant `λ` and external field `h`.
->>>>>>> master
+Constructs the impurity tensor for a 2D square lattice for the complex ϕ^4 model with a given approximation `K`, bare mass µ_0^2 `μ0` and interaction constant `λ`.
 
 The impurity is a ϕ operator on this site.
     
@@ -262,12 +252,7 @@ end
 """
 $(SIGNATURES)
 
-Constructs the impurity tensor for a 2D square lattice
-<<<<<<< SmallImprovementComplexPhi4
-for the complex ϕ^4 model with a given approximation `K`, bare mass µ_0^2 `μ0` and interaction constant `λ`.
-=======
-for the complex ϕ^4 model with a given approximation (and bond dimension) `K`, bare mass ``µ_0^2`` `μ0`, interaction constant `λ` and external field `h`.
->>>>>>> master
+Constructs the impurity tensor for a 2D square lattice for the complex ϕ^4 model with a given approximation `K`, bare mass µ_0^2 `μ0` and interaction constant `λ`.
 
 The impurity is a ϕ† operator on this site.
 
@@ -335,12 +320,7 @@ end
 """
 $(SIGNATURES)
 
-Constructs the impurity tensor for a 2D square lattice
-<<<<<<< SmallImprovementComplexPhi4
-for the complex ϕ^4 model with a given approximation `K`, bare mass µ_0^2 `μ0` and interaction constant `λ`.
-=======
-for the complex ϕ^4 model with a given approximation (and bond dimension) `K`, bare mass ``µ_0^2`` `μ0`, interaction constant `λ` and external field `h`.
->>>>>>> master
+Constructs the impurity tensor for a 2D square lattice for the complex ϕ^4 model with a given approximation `K`, bare mass µ_0^2 `μ0` and interaction constant `λ`.
 
 The impurity is a √(ϕϕ†) operator on this site.
     
@@ -408,12 +388,7 @@ end
 """
 $(SIGNATURES)
 
-Constructs the impurity tensor for a 2D square lattice
-<<<<<<< SmallImprovementComplexPhi4
-for the complex ϕ^4 model with a given approximation `K`, bare mass µ_0^2 `μ0` and interaction constant `λ`.
-=======
-for the complex ϕ^4 model with a given approximation (and bond dimension) `K`, bare mass ``µ_0^2`` `μ0`, interaction constant `λ` and external field `h`.
->>>>>>> master
+Constructs the impurity tensor for a 2D square lattice for the complex ϕ^4 model with a given approximation `K`, bare mass µ_0^2 `μ0` and interaction constant `λ`.
 
 The impurity is a ϕϕ† operator on this site.
     
@@ -482,12 +457,7 @@ end
 """
 $(SIGNATURES)
 
-Constructs all the tensors: the partition function tensor and all the impurity tensors for a 2D square lattice
-<<<<<<< SmallImprovementComplexPhi4
-for the complex ϕ^4 model with a given approximation `K`, bare mass µ_0^2 `μ0` and interaction constant `λ`.
-=======
-for the complex ϕ^4 model with a given approximation (and bond dimension) `K`, bare mass ``µ_0^2`` `μ0`, interaction constant `λ` and external field `h`.
->>>>>>> master
+Constructs all the tensors: the partition function tensor and all the impurity tensors for a 2D square lattice for the complex ϕ^4 model with a given approximation `K`, bare mass µ_0^2 `μ0` and interaction constant `λ`.
 
 It is faster to compute them all at once then one for one individually.
 
@@ -580,12 +550,7 @@ end
 """
 $(SIGNATURES)
 
-Constructs the partition function tensor for a 2D square lattice
-<<<<<<< SmallImprovementComplexPhi4
-for the complex ϕ^4 model with a given approximation `K`, bare mass µ_0^2 `μ0` and interaction constant `λ`.
-=======
-for the complex ϕ^4 model with a given approximation (and bond dimension) `K`, bare mass ``µ_0^2`` `μ0`, interaction constant `λ`.
->>>>>>> master
+Constructs the partition function tensor for a 2D square lattice for the complex ϕ^4 model with a given approximation `K`, bare mass µ_0^2 `μ0` and interaction constant `λ`.
 
 This tensor has explicit U(1) symmetry on each of its spaces.
 


### PR DESCRIPTION
- Removed incorrect mentions of external field `h` from the docs.
- Made all tensors of type `ComplexF64`