### PR TITLE
remove the `finalize_beginning` functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ scheme = BTRG(T) # Bond-weighted TRG (excellent choice)
 data = run!(scheme, truncrank(16), maxiter(25)) # max bond-dimension of 16, for 25 iterations
 ```
 
-`data` now contains 26 norms of the tensor, 1 for every time the tensor was normalized. (By default there is a normalization step before the first coarse-graining step wich can be turned off by changing the kwarg `run!(...; finalize_beginning=false)`)
+`data` now contains 26 norms of the tensor, 1 for every time the tensor was normalized. (There is a normalization step before the first coarse-graining step)
 
 Using these norms you could, for example, calculate the free energy of the critical classical Ising model:
 ```Julia

--- a/docs/src/finalizers.md
+++ b/docs/src/finalizers.md
@@ -1,5 +1,5 @@
 # Finalizers
-At the end of every TNR step (and before the first step if `finalize_beginning=true` is chose in the `run!` function, which is default behaviour), the state of the scheme is finalized.
+At the end of every TNR step (and before the first step), the state of the scheme is "finalized".
 
 By default this finalization process is as follow:
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -56,7 +56,7 @@ T = classical_ising_symmetric(ising_βc) # partition function of classical Ising
 scheme = BTRG(T) # Bond-weighted TRG (excellent choice)
 data = run!(scheme, truncrank(16), maxiter(25)) # max bond-dimension of 16, for 25 iterations
 ```
-`data` now contains 26 norms of the tensor, 1 for every time the tensor was normalized. (By default there is a normalization step before the first coarse-graining step wich can be turned off by changing the kwarg `run!(...; finalize_beginning=false)`)
+`data` now contains 26 norms of the tensor, 1 for every time the tensor was normalized. (There is a normalization step before the first coarse-graining step)
 
 Using these norms you could, for example, calculate the free energy of the critical classical Ising model:
 ```Julia

--- a/examples/example.jl
+++ b/examples/example.jl
@@ -12,9 +12,8 @@ trunc = truncrank(16) & trunctol(atol = 1.0e-40)
 # initialize the TRG scheme
 scheme = TRG(classical_ising(1.0))
 
-# run the TRG scheme (and normalize and store the norm in the beginning (finalize_beginning=true))
-data = run!(scheme, trunc, stopping_criterion; finalize_beginning = true)
-# or: data = run!(scheme, truncrank(16)), this will default to maxiter(100)
+# run the TRG scheme
+data = run!(scheme, trunc, stopping_criterion)
 
 # initialize the BTRG scheme
 scheme = BTRG(classical_ising(1.0), -0.5)

--- a/src/schemes/atrg.jl
+++ b/src/schemes/atrg.jl
@@ -7,7 +7,7 @@ Anisotropic Tensor Renormalization Group
     $(FUNCTIONNAME)(T)
 
 ### Running the algorithm
-    run!(::ATRG, trunc::TruncationStrategy, stop::Stopcrit[, finalizer=default_Finalizer, finalize_beginning=true, verbosity=1])
+    run!(::ATRG, trunc::TruncationStrategy, stop::Stopcrit[, finalizer=default_Finalizer, verbosity=1])
 
 Each step rescales the lattice by a (linear) factor of √2
 

--- a/src/schemes/atrg3d.jl
+++ b/src/schemes/atrg3d.jl
@@ -7,7 +7,7 @@ $(TYPEDEF)
     $(FUNCTIONNAME)(T)
 
 ### Running the algorithm
-    run!(::ATRG_3D, trunc::TruncationStrategy, stop::Stopcrit[, finalizer=defualt_Finalizer, finalize_beginning=true,verbosity=1])
+    run!(::ATRG_3D, trunc::TruncationStrategy, stop::Stopcrit[, finalizer=default_Finalizer, verbosity=1])
 
 Each step rescales the lattice by a (linear) factor of 2
 

--- a/src/schemes/btrg.jl
+++ b/src/schemes/btrg.jl
@@ -7,7 +7,7 @@ Bond-weighted Tensor Renormalization Group
     $(FUNCTIONNAME)(T [, k=-1/2])
 
 ### Running the algorithm
-    run!(::BTRG, trunc::TruncationStrategy, stop::Stopcrit[, finalizer=default_Finalizer, finalize_beginning=true, verbosity=1])
+    run!(::BTRG, trunc::TruncationStrategy, stop::Stopcrit[, finalizer=default_Finalizer, verbosity=1])
 
 Each step rescales the lattice by a (linear) factor of √2
 

--- a/src/schemes/ctm/c3vctm_honeycomb.jl
+++ b/src/schemes/ctm/c3vctm_honeycomb.jl
@@ -25,7 +25,7 @@ or with a (0,3) tensor (120°, 0°, 240°) where all arrows point inward (unflip
 The keyword argument symmetrize makes the tensor C6v symmetric when set to true. If symmetrize = false, it checks the symmetry explicitly.
 
 ### Running the algorithm
-    run!(::CTM, trunc::TruncationStrategy, stop::Stopcrit[, finalize_beginning=true, verbosity=1])
+    run!(::CTM, trunc::TruncationStrategy, stop::Stopcrit[, verbosity=1])
 
 !!! info "verbosity levels"
     - 0: No output

--- a/src/schemes/ctm/c4vctm.jl
+++ b/src/schemes/ctm/c4vctm.jl
@@ -12,7 +12,7 @@ or with a (0,4) tensor (North, East, South, West) (unflipped arrow convention).
 The keyword argument symmetrize makes the tensor C4v symmetric when set to true. If symmetrize = false, it checks the symmetry explicitly.
 
 ### Running the algorithm
-    run!(::c4vCTM, trunc::TruncationStrategy, stop::Stopcrit[, finalize_beginning=true, verbosity=1])
+    run!(::c4vCTM, trunc::TruncationStrategy, stop::Stopcrit[, verbosity=1])
 
 !!! info "verbosity levels"
     - 0: No output

--- a/src/schemes/ctm/triangular.jl
+++ b/src/schemes/ctm/triangular.jl
@@ -25,7 +25,7 @@ or with a (0,6) tensor (120°, 60°, 0°, 300°, 240°, 180°) where all arrows 
 The keyword argument symmetrize makes the tensor C6v symmetric when set to true. If symmetrize = false, it checks the symmetry explicitly.
 
 ### Running the algorithm
-    run!(::CTM, trunc::TruncationStrategy, stop::Stopcrit[, finalize_beginning=true, verbosity=1])
+    run!(::CTM, trunc::TruncationStrategy, stop::Stopcrit[, verbosity=1])
 
 !!! info "verbosity levels"
     - 0: No output
@@ -100,7 +100,7 @@ or with a (0,6) tensor (120°, 60°, 0°, 300°, 240°, 180°) where all arrows 
 The keyword argument symmetrize makes the tensor C6v symmetric when set to true. If symmetrize = false, it checks the symmetry explicitly.
 
 ### Running the algorithm
-    run!(::c6vCTM, trunc::MatrixAlgebraKit.TruncationStrategy, stop::Stopcrit[, finalize_beginning=true, projectors=:twothirds, conditioning=true, verbosity=1])
+    run!(::c6vCTM, trunc::MatrixAlgebraKit.TruncationStrategy, stop::Stopcrit[, projectors=:twothirds, conditioning=true, verbosity=1])
 
 `projectors` can either be :twothirds or :full, determining the type of projectors used in the renormalization step. This is based on https://arxiv.org/abs/2510.04907v1.
 `conditioning` determines whether to condition the second projector construction. This is based on https://doi.org/10.1103/PhysRevB.98.235148.

--- a/src/schemes/hotrg.jl
+++ b/src/schemes/hotrg.jl
@@ -7,7 +7,7 @@ Higher-Order Tensor Renormalization Group
     $(FUNCTIONNAME)(T)
 
 ### Running the algorithm
-    run!(::HOTRG, trunc::TruncationStrategy, stop::Stopcrit[, finalizer=default_Finalizer, finalize_beginning=true, verbosity=1])
+    run!(::HOTRG, trunc::TruncationStrategy, stop::Stopcrit[, finalizer=default_Finalizer, verbosity=1])
 
 Each step rescales the lattice by a (linear) factor of 2
 

--- a/src/schemes/hotrg3d.jl
+++ b/src/schemes/hotrg3d.jl
@@ -7,7 +7,7 @@ $(TYPEDEF)
     $(FUNCTIONNAME)(T)
 
 ### Running the algorithm
-    run!(::HOTRG_3D, trunc::TruncationStrategy, stop::Stopcrit[, finalizer=default_Finalizer, finalize_beginning=true, verbosity=1])
+    run!(::HOTRG_3D, trunc::TruncationStrategy, stop::Stopcrit[, finalizer=default_Finalizer, verbosity=1])
 
 Each step rescales the lattice by a (linear) factor of 2
 

--- a/src/schemes/impurityhotrg.jl
+++ b/src/schemes/impurityhotrg.jl
@@ -7,7 +7,7 @@ Single impurity method for Higher-Order Tensor Renormalization Group (for 2nd or
     $(FUNCTIONNAME)(T, T_imp_order1_1, T_imp_order1_2, T_imp_order2)
 
 ### Running the algorithm
-    run!(::ImpurityHOTRG, trunc::TruncationStrategy, stop::Stopcrit[, finalizer=ImpurityHOTRG_Finalizer, finalize_beginning=true, verbosity=1])
+    run!(::ImpurityHOTRG, trunc::TruncationStrategy, stop::Stopcrit[, finalizer=ImpurityHOTRG_Finalizer, verbosity=1])
 
 Each step rescales the lattice by a (linear) factor of 2
 

--- a/src/schemes/impuritytrg.jl
+++ b/src/schemes/impuritytrg.jl
@@ -7,7 +7,7 @@ Impurity method for Tensor Renormalization Group
     $(FUNCTIONNAME)(T, T_imp1, T_imp2, T_imp3, T_imp4)
 
 ### Running the algorithm
-    run!(::ImpurityTRG, trunc::TruncationStrategy, stop::Stopcrit[, finalizer=ImpurityTRG_Finalizer, finalize_beginning=true, verbosity=1])
+    run!(::ImpurityTRG, trunc::TruncationStrategy, stop::Stopcrit[, finalizer=ImpurityTRG_Finalizer, verbosity=1])
 
 Each step rescales the lattice by a (linear) factor of √2
 

--- a/src/schemes/looptnr.jl
+++ b/src/schemes/looptnr.jl
@@ -10,11 +10,11 @@ Loop Optimization for Tensor Network Renormalization
 
 ### Running the algorithm
     run!(::LoopTNR, trunc::TruncationStrategy, criterion::stopcrit, parameters::LoopParameters, finalizer::Finalizer[,
-              entanglement_criterion::stopcrit, finalize_beginning=true, verbosity=1])
+              entanglement_criterion::stopcrit, verbosity=1])
     
     run!(::LoopTNR, trscheme::TruncationStrategy, criterion::stopcrit, parameters::LoopParameters; kwargs...)
 
-    run!(::LoopTNR, trscheme::TruncationStrategy, criterion::stopcrit[finalize_beginning=true, verbosity=1])
+    run!(::LoopTNR, trscheme::TruncationStrategy, criterion::stopcrit[, verbosity=1])
 
 ### LoopParameters
 See also: [`LoopParameters`](@ref)
@@ -491,16 +491,15 @@ function run!(
         criterion::stopcrit, loop_condition::LoopParameters,
         finalizer::Finalizer{E};
         entanglement_criterion = default_entanglement_criterion,
-        finalize_beginning = true,
         verbosity = 1
     ) where {E}
     data = Vector{E}()
 
     LoggingExtras.withlevel(; verbosity) do
         @infov 1 "Starting simulation\n $(scheme)\n"
-        if finalize_beginning
-            push!(data, finalizer.f!(scheme))
-        end
+
+        # Finalize the initial state
+        push!(data, finalizer.f!(scheme))
 
         steps = 0
         crit = true
@@ -523,14 +522,10 @@ function run!(scheme, trscheme, criterion, loop_condition; kwargs...)
     return run!(scheme, trscheme, criterion, loop_condition, default_Finalizer; kwargs...)
 end
 
-function run!(
-        scheme::LoopTNR, trscheme::TruncationStrategy, criterion::stopcrit;
-        finalize_beginning = true, verbosity = 1
-    )
+function run!(scheme::LoopTNR, trscheme::TruncationStrategy, criterion::stopcrit; verbosity = 1)
     loop_condition = LoopParameters()
     return run!(
         scheme, trscheme, criterion, loop_condition;
-        finalize_beginning = finalize_beginning,
         verbosity = verbosity
     )
 end

--- a/src/schemes/symmetric_looptnr.jl
+++ b/src/schemes/symmetric_looptnr.jl
@@ -9,7 +9,7 @@ c4 & inversion symmetric Loop Optimization for Tensor Network Renormalization
 
 ### Running the algorithm
     run!(::SLoopTNR, trscheme::TruncationStrategy,
-              criterion::TNRKit.stopcrit[, finalizer=default_Finalizer, finalize_beginning=true, oneloop=true,
+              criterion::TNRKit.stopcrit[, finalizer=default_Finalizer, oneloop=true,
               verbosity=1])
 
 `oneloop=true` will use disentangled tensors as a starting guess for the optimization.
@@ -194,7 +194,7 @@ end
 
 function run!(
         scheme::SLoopTNR, trscheme::TruncationStrategy,
-        criterion::TNRKit.stopcrit; finalizer = default_Finalizer, finalize_beginning = true, oneloop = true,
+        criterion::TNRKit.stopcrit; finalizer = default_Finalizer, oneloop = true,
         verbosity = 1
     )
     data = output_type(finalizer)[]
@@ -202,9 +202,9 @@ function run!(
     LoggingExtras.withlevel(; verbosity) do
         @infov 1 "Starting simulation\n $(scheme)\n"
 
-        if finalize_beginning
-            push!(data, finalizer.f!(scheme))
-        end
+        # Finlize the initial state
+        push!(data, finalizer.f!(scheme))
+
         steps = 0
         crit = true
 

--- a/src/schemes/tnrscheme.jl
+++ b/src/schemes/tnrscheme.jl
@@ -10,7 +10,7 @@ Finalizer for TNR schemes
 ### Constructors
     Finalizer(f!::Function, E::Type)
 
-A Finalizer holds a function `f!` that is to be applied to a TNR scheme after each step of the algorithm (and at the beginning if specified by `run!(;finalize_beginning=true)`, which is the default behavior).
+A Finalizer holds a function `f!` that is to be applied to a TNR scheme after each step of the algorithm (and at the beginning).
 The type parameter `E` indicates the output type of `f!`, which is used to create an array of the correct type to hold the outputs.
 """
 struct Finalizer{E} # E is the output type of f
@@ -30,15 +30,15 @@ const ImpurityHOTRG_Finalizer = Finalizer(finalize!, Tuple{Float64, Float64, Flo
 # Finalization functions for the various TNR schemes
 abstract type TNRScheme{E, S} end
 
-function run!(scheme::TNRScheme, trscheme::TruncationStrategy, criterion::stopcrit, finalizer::Finalizer{E}; finalize_beginning = true, verbosity = 1) where {E}
+function run!(scheme::TNRScheme, trscheme::TruncationStrategy, criterion::stopcrit, finalizer::Finalizer{E}; verbosity = 1) where {E}
     data = Vector{E}()
 
     LoggingExtras.withlevel(; verbosity) do
 
         @infov 1 "Starting simulation\n $(scheme)\n"
-        if finalize_beginning
-            push!(data, finalizer.f!(scheme))
-        end
+
+        # Finalize the initial state
+        push!(data, finalizer.f!(scheme))
 
         steps = 0
         crit = true

--- a/src/schemes/trg.jl
+++ b/src/schemes/trg.jl
@@ -7,7 +7,7 @@ Tensor Renormalization Group
     $(FUNCTIONNAME)(T)
 
 ### Running the algorithm
-    run!(::TRG, trunc::TruncationStrategy, stop::Stopcrit[, finalizer=default_Finalizer, finalize_beginning=true, verbosity=1])
+    run!(::TRG, trunc::TruncationStrategy, stop::Stopcrit[, finalizer=default_Finalizer, verbosity=1])
 
 Each step rescales the lattice by a (linear) factor of √2
 


### PR DESCRIPTION
Today is the day I attempt to remove the `finalize_beginning` functionality. I don't think anyone has ever used it and it has been cluttering docstrings since day one.

@Adwait-Naravane @dartsushi do you guys agree that it makes sense to just ALWAYS normalize before the first course-graining step in TNRKit?