### PR TITLE
Test Krylov and NNR LoopTNR methods

### DIFF
--- a/test/schemes.jl
+++ b/test/schemes.jl
@@ -165,7 +165,7 @@ end
 end
 
 # LoopTNR
-@testset "LoopTNR - Ising Model" begin
+@testset "LoopTNR - Ising Model - Dense Solver" begin
     @info "LoopTNR ising free energy"
     scheme = LoopTNR(T)
 
@@ -219,6 +219,59 @@ end
     @test X1 ≈ 2.0 rtol = 1.0e-2
     @test X2 ≈ 2.0 rtol = 1.0e-2
 end
+
+@testset "LoopTNR - Ising Model - Dense Solver - NNR" begin
+    @info "LoopTNR ising free energy"
+    scheme = LoopTNR(T)
+
+    loop_condition = LoopParameters(
+        sweeping = maxiter(5) & convcrit(1.0e-9, (steps, cost) -> abs(cost[end])),
+        truncentanglement = trunctol(atol = 1.0e-12),
+        nuclear_norm = true
+    )
+
+    data = run!(
+        scheme, truncrank(8), maxiter(25), loop_condition
+    )
+
+    @test free_energy(data, ising_βc) ≈ f_onsager rtol = 1.0e-6
+end
+
+@testset "LoopTNR - Ising Model - Krylov Solver" begin
+    @info "LoopTNR ising free energy"
+    scheme = LoopTNR(T)
+
+    loop_condition = LoopParameters(
+        sweeping = maxiter(5) & convcrit(1.0e-9, (steps, cost) -> abs(cost[end])),
+        truncentanglement = trunctol(atol = 1.0e-12),
+        krylov = true
+    )
+
+    data = run!(
+        scheme, truncrank(8), maxiter(25), loop_condition
+    )
+
+    @test free_energy(data, ising_βc) ≈ f_onsager rtol = 1.0e-6
+end
+
+@testset "LoopTNR - Ising Model - Krylov Solver- NNR" begin
+    @info "LoopTNR ising free energy"
+    scheme = LoopTNR(T)
+
+    loop_condition = LoopParameters(
+        sweeping = maxiter(5) & convcrit(1.0e-9, (steps, cost) -> abs(cost[end])),
+        truncentanglement = trunctol(atol = 1.0e-12),
+        krylov = true,
+        nuclear_norm = true
+    )
+
+    data = run!(
+        scheme, truncrank(8), maxiter(25), loop_condition
+    )
+
+    @test free_energy(data, ising_βc) ≈ f_onsager rtol = 1.0e-6
+end
+
 
 @testset "LoopTNR - Initialization with 2 x 2 unit cell" begin
     loop_condition = LoopParameters(


### PR DESCRIPTION
Since switching to a dense solver for the Linear Problem (#144), we have only been testing that one. The nuclear norm code also was not included in the tests. This PR fixes that.