### PR TITLE
Small fixes

### DIFF
--- a/src/schemes/ctm/ctm_honeycomb.jl
+++ b/src/schemes/ctm/ctm_honeycomb.jl
@@ -3,7 +3,7 @@ function run!(
         verbosity = 1
     )
     LoggingExtras.withlevel(; verbosity) do
-        @infov 1 "Starting simulation\n"
+        @infov 1 "Starting simulation\n $(scheme)\n"
         steps = 0
         crit = true
         ε = Inf

--- a/src/schemes/ctm/honeycomb.jl
+++ b/src/schemes/ctm/honeycomb.jl
@@ -74,6 +74,15 @@ function c3vCTM_honeycomb_init(T::TensorMap{A, S, 0, 3}) where {A, S}
     return C, L, R
 end
 
+function Base.show(io::IO, scheme::c3vCTM_honeycomb)
+    println(io, "c3vCTM_honeycomb - Corner Transfer Matrix for honeycomb lattice")
+    println(io, "  * T: $(summary(scheme.T))")
+    println(io, "  * C: $(summary(scheme.C))")
+    println(io, "  * L: $(summary(scheme.L))")
+    println(io, "  * R: $(summary(scheme.R))")
+    return nothing
+end
+
 # Functions to permute (unflipped) tensors under 120 degree rotation
 function rotl120_pf_honeycomb(T::TensorMap{A, S, 0, 3}) where {A, S}
     return permute(T, ((), (2, 3, 1)))
@@ -165,4 +174,14 @@ function CTM_honeycomb_init(A::TensorMap{E, S, 0, 3}; B::TensorMap{E, S, 0, 3} =
     Ta = [ones(S_type, oneunit(Vp) ⊗ space(B)[mod1(dir - 1, 3)]' ← oneunit(Vp)) for dir in 1:3]
     Tb = [ones(S_type, oneunit(Vp) ⊗ space(A)[mod1(dir + 1, 3)]' ← oneunit(Vp)) for dir in 1:3]
     return C, Ta, Tb
+end
+
+function Base.show(io::IO, scheme::CTM_honeycomb)
+    println(io, "CTM_honeycomb - Corner Transfer Matrix for honeycomb lattice")
+    println(io, "  * A: $(summary(scheme.A))")
+    println(io, "  * B: $(summary(scheme.B))")
+    println(io, "  * C: $(summary(scheme.C))")
+    println(io, "  * Ta: $(summary(scheme.Ta))")
+    println(io, "  * Tb: $(summary(scheme.Tb))")
+    return nothing
 end

--- a/src/schemes/looptnr.jl
+++ b/src/schemes/looptnr.jl
@@ -65,7 +65,8 @@ It also allows the user to turn on nuclear norm regularization.
     # Krylov parameters
     "Use Krylov methods to solve the linear system in loop optimization. Default = false, which uses the backslash operator."
     krylov::Bool = false
-    krylovalg::A = GMRES(; verbosity = 0)
+    "Default Krylov algorithm is GMRES with maxiter = 250, krylovdim = 128, tol = 1.0e-10, verbosity = 0."
+    krylovalg::A = GMRES(; maxiter = 250, krylovdim = 128, tol = 1.0e-10, verbosity = 0)
 
     # NNR parameters
     "Use Nuclear Norm Regularisation. Default = false"


### PR DESCRIPTION
- Add a show method to the two honecomb CTM methods.
- Change the KrylovAlg default parameters to get rid of the "linsolve did not converge" spam in the testlogs.