### PR TITLE
Implement PTMRG

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,6 @@ OptimKit = "77e91f04-9b3b-57a6-a776-40b61faaebe0"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
-StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 TensorKit = "07d1fe3e-3e46-537d-9eac-e9e13d0d4cec"
 TensorKitSectors = "13a9c161-d5da-41f0-bcbd-e1a08ae0647f"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
@@ -39,6 +38,7 @@ julia = "1.11"
 [extras]
 QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 
 [targets]
-test = ["Test", "QuadGK"]
+test = ["Test", "QuadGK", "StableRNGs"]

--- a/docs/src/assets/tnrkit.bib
+++ b/docs/src/assets/tnrkit.bib
@@ -225,18 +225,18 @@
 }
 
 @article{nyckees2023,
-  title = {Critical line of the triangular Ising antiferromagnet in a field from a ${C}_{3}$-symmetric corner transfer matrix algorithm},
-  author = {Nyckees, Samuel and Rufino, Afonso and Mila, Fr\'ed\'eric and Colbois, Jeanne},
-  journal = {Phys. Rev. E},
-  volume = {108},
-  issue = {6},
-  pages = {064132},
-  numpages = {14},
-  year = {2023},
-  month = {Dec},
+  title     = {Critical line of the triangular Ising antiferromagnet in a field from a ${C}_{3}$-symmetric corner transfer matrix algorithm},
+  author    = {Nyckees, Samuel and Rufino, Afonso and Mila, Fr\'ed\'eric and Colbois, Jeanne},
+  journal   = {Phys. Rev. E},
+  volume    = {108},
+  issue     = {6},
+  pages     = {064132},
+  numpages  = {14},
+  year      = {2023},
+  month     = {Dec},
   publisher = {American Physical Society},
-  doi = {10.1103/PhysRevE.108.064132},
-  url = {https://link.aps.org/doi/10.1103/PhysRevE.108.064132}
+  doi       = {10.1103/PhysRevE.108.064132},
+  url       = {https://link.aps.org/doi/10.1103/PhysRevE.108.064132}
 }
 
 @article{homma2024a,
@@ -252,9 +252,9 @@
 @article{Yu_2014,
   title     = {Tensor renormalization group study of classical XY model on the square lattice},
   volume    = {89},
-  ISSN      = {1550-2376},
+  issn      = {1550-2376},
   url       = {http://dx.doi.org/10.1103/PhysRevE.89.013308},
-  DOI       = {10.1103/physreve.89.013308},
+  doi       = {10.1103/physreve.89.013308},
   number    = {1},
   journal   = {Physical Review E},
   publisher = {American Physical Society (APS)},
@@ -264,40 +264,53 @@
 }
 
 @phdthesis{Bao2019LoopTNR,
-  author       = {Chenfeng Bao},
-  title        = {Loop Optimization of Tensor Network Renormalization: Algorithms and Applications},
-  school       = {University of Waterloo},
-  year         = {2019},
-  month        = {May},
-  type         = {PhD thesis},
-  advisor      = {Neil Turok},
-  url          = {http://hdl.handle.net/10012/14674}
+  author  = {Chenfeng Bao},
+  title   = {Loop Optimization of Tensor Network Renormalization: Algorithms and Applications},
+  school  = {University of Waterloo},
+  year    = {2019},
+  month   = {May},
+  type    = {PhD thesis},
+  advisor = {Neil Turok},
+  url     = {http://hdl.handle.net/10012/14674}
 }
 
 @article{Hauru_2016,
-   title      = {Topological conformal defects with tensor networks},
-   volume     = {94},
-   ISSN       = {2469-9969},
-   url        = {http://dx.doi.org/10.1103/PhysRevB.94.115125},
-   DOI        = {10.1103/physrevb.94.115125},
-   number     = {11},
-   journal    = {Physical Review B},
-   publisher  = {American Physical Society (APS)},
-   author     = {Hauru, Markus and Evenbly, Glen and Ho, Wen Wei and Gaiotto, Davide and Vidal, Guifre},
-   year       = {2016},
-   month      = {sep}
+  title     = {Topological conformal defects with tensor networks},
+  volume    = {94},
+  issn      = {2469-9969},
+  url       = {http://dx.doi.org/10.1103/PhysRevB.94.115125},
+  doi       = {10.1103/physrevb.94.115125},
+  number    = {11},
+  journal   = {Physical Review B},
+  publisher = {American Physical Society (APS)},
+  author    = {Hauru, Markus and Evenbly, Glen and Ho, Wen Wei and Gaiotto, Davide and Vidal, Guifre},
+  year      = {2016},
+  month     = {sep}
 }
 
 @article{Evenbly_2018,
-   title      = {Gauge fixing, canonical forms, and optimal truncations in tensor networks with closed loops},
-   volume     = {98},
-   ISSN       = {2469-9969},
-   url        = {http://dx.doi.org/10.1103/PhysRevB.98.085155},
-   DOI        = {10.1103/physrevb.98.085155},
-   number     = {8},
-   journal    = {Physical Review B},
-   publisher  = {American Physical Society (APS)},
-   author     = {Evenbly, Glen},
-   year       = {2018},
-   month      = {aug} 
+  title     = {Gauge fixing, canonical forms, and optimal truncations in tensor networks with closed loops},
+  volume    = {98},
+  issn      = {2469-9969},
+  url       = {http://dx.doi.org/10.1103/PhysRevB.98.085155},
+  doi       = {10.1103/physrevb.98.085155},
+  number    = {8},
+  journal   = {Physical Review B},
+  publisher = {American Physical Society (APS)},
+  author    = {Evenbly, Glen},
+  year      = {2018},
+  month     = {aug}
+}
+
+@article{fedorovich2025,
+  title        = {Finite-Size Scaling on the Torus with Periodic Projected Entangled-Pair States},
+  author       = {Fedorovich, Gleb and Devos, Lukas and Haegeman, Jutho and Vanderstraeten, Laurens and Verstraete, Frank and Ueda, Atsushi},
+  date         = {2025-04-14},
+  journaltitle = {Physical Review B},
+  shortjournal = {Phys. Rev. B},
+  volume       = {111},
+  number       = {16},
+  publisher    = {American Physical Society},
+  doi          = {10.1103/PhysRevB.111.165124},
+  url          = {https://link.aps.org/doi/10.1103/PhysRevB.111.165124}
 }

--- a/src/TNRKit.jl
+++ b/src/TNRKit.jl
@@ -26,6 +26,7 @@ include("schemes/hotrg.jl")
 include("schemes/hotrg3d.jl")
 include("schemes/atrg.jl")
 include("schemes/atrg3d.jl")
+include("schemes/ptmrg.jl")
 
 # CTM methods
 include("schemes/ctm/utility.jl")
@@ -62,6 +63,7 @@ export HOTRG
 export HOTRG_3D
 export ATRG
 export ATRG_3D
+export PTMRG
 
 export CTM
 export Sublattice_CTM

--- a/src/schemes/ptmrg.jl
+++ b/src/schemes/ptmrg.jl
@@ -1,0 +1,62 @@
+"""
+$(TYPEDEF)
+
+Periodic Transfer Matrix Renormalization Group 
+
+### Constructors
+    $(FUNCTIONNAME)(T)
+
+### Running the algorithm
+    run!(::PTMRG, trunc::TruncationStrategy, stop::Stopcrit[, finalizer=default_Finalizer, finalize_beginning=true, verbosity=1])
+
+# TODO: add the proper scaling factor here
+Each step rescales the lattice by a (linear) factor of 2
+
+!!! info "verbosity levels"
+    - 0: No output
+    - 1: Print information at start and end of the algorithm
+    - 2: Print information at each step
+
+### Fields
+
+$(TYPEDFIELDS)
+
+### References
+* [Fedorovich et. al. Phys. Rev. B 111 (2025)](@cite fedorovich2025)
+
+"""
+mutable struct PTMRG{E, S, TT <: AbstractTensorMap{E, S, 2, 2}} <: TNRScheme{E, S}
+    "Central tensor"
+    T::TT
+    C::TT
+    h::TT
+    v::TT
+
+    function PTMRG(T::TT) where {E, S, TT <: AbstractTensorMap{E, S, 2, 2}}
+        return new{E, S, TT}(T, copy(T), copy(T), copy(T))
+    end
+end
+
+function step!(scheme::PTMRG, trunc::MatrixAlgebraKit.TruncationStrategy)
+    Ux, = _get_hotrg_xproj(scheme.h, scheme.C, trunc)
+    scheme.C = _step_hotrg_y(scheme.h, scheme.C, Ux)
+
+    Ux, = _get_hotrg_xproj(scheme.T, scheme.v, trunc)
+    scheme.v = _step_hotrg_y(scheme.T, scheme.v, Ux)
+
+    Uy, = _get_hotrg_yproj(scheme.C, scheme.v, trunc)
+    scheme.C = _step_hotrg_x(scheme.C, scheme.v, Uy)
+
+    Uy, = _get_hotrg_yproj(scheme.h, scheme.T, trunc)
+    scheme.h = _step_hotrg_x(scheme.h, scheme.T, Uy)
+    return scheme
+end
+
+function Base.show(io::IO, scheme::PTMRG)
+    println(io, "PTMRG - Periodic Tranfer Matrix Renormalization Group")
+    println(io, "  * T: $(summary(scheme.T))")
+    println(io, "  * C: $(summary(scheme.C))")
+    println(io, "  * h: $(summary(scheme.h))")
+    println(io, "  * v: $(summary(scheme.v))")
+    return nothing
+end

--- a/src/schemes/ptmrg.jl
+++ b/src/schemes/ptmrg.jl
@@ -41,13 +41,11 @@ function step!(scheme::PTMRG, trunc::MatrixAlgebraKit.TruncationStrategy)
     Ux, = _get_hotrg_xproj(scheme.h, scheme.C, trunc)
     scheme.C = _step_hotrg_y(scheme.h, scheme.C, Ux)
 
-    Ux, = _get_hotrg_xproj(scheme.T, scheme.v, trunc)
     scheme.v = _step_hotrg_y(scheme.T, scheme.v, Ux)
 
     Uy, = _get_hotrg_yproj(scheme.C, scheme.v, trunc)
     scheme.C = _step_hotrg_x(scheme.C, scheme.v, Uy)
 
-    Uy, = _get_hotrg_yproj(scheme.h, scheme.T, trunc)
     scheme.h = _step_hotrg_x(scheme.h, scheme.T, Uy)
     return scheme
 end

--- a/src/utility/finalize.jl
+++ b/src/utility/finalize.jl
@@ -13,6 +13,14 @@ function finalize!(scheme::BTRG)
     return n
 end
 
+function finalize!(scheme::PTMRG)
+    scheme.h /= norm(@tensor scheme.h[1 2; 2 1])
+    scheme.v /= norm(@tensor scheme.v[1 2; 2 1])
+    n = norm(@tensor scheme.C[1 2; 2 1])
+    scheme.C /= n
+    return n
+end
+
 # 2x2 unitcell finalize
 function finalize_two_by_two!(scheme::simple_scheme)
     n = norm(


### PR DESCRIPTION
This PR implements the PTMRG algorithm from https://arxiv.org/pdf/2411.12731 
To do before merging:
- [ ]  Implement tests
- [ ] Figure out how to get free energies from the data
- [ ] Figure out which norms to take as data
- [ ] Figure out how to normalize the h, v and C tensors
- [ ] Check if the contraction ordering for the HOTRG projectors is optimal. (In HOTRG all legs have the same dimension, in PTMRG there is a big difference between the two tensors being merged)