### PR TITLE
Use HTSE free energy to benchmark 3D Ising

### DIFF
--- a/src/TNRKit.jl
+++ b/src/TNRKit.jl
@@ -93,7 +93,7 @@ include("models/ising.jl")
 include("models/ising_triangular.jl")
 include("models/ising_honeycomb.jl")
 export classical_ising, ising_βc, f_onsager, ising_cft_exact,
-    ising_βc_3D, classical_ising_3D, classical_ising_impurity,
+    ising_βc_3D, classical_ising_3D, ising_3D_free_energy_htse, classical_ising_impurity,
     classical_ising_triangular, ising_βc_triangular, f_onsager_triangular,
     classical_ising_honeycomb, ising_βc_honeycomb, f_onsager_honeycomb
 

--- a/src/models/ising.jl
+++ b/src/models/ising.jl
@@ -7,6 +7,75 @@ const ising_cft_exact = [
 ]
 const ising_βc_3D = 1.0 / 4.51152469
 
+# HTSE coefficients for the 3D Ising free energy (hep-lat/9312048, Table 2).
+const ISING_3D_HTSE_COEFFS = [
+    0,              # k=0
+    0,              # k=1
+    0,              # k=2
+    0,              # k=3
+    3,              # k=4
+    0,              # k=5
+    22,             # k=6
+    0,              # k=7
+    375 // 2,         # k=8
+    0,              # k=9
+    1980,           # k=10
+    0,              # k=11
+    24044,          # k=12
+    0,              # k=13
+    319170,         # k=14
+    0,              # k=15
+    18059031 // 4,    # k=16
+    0,              # k=17
+    201010408 // 3,   # k=18
+    0,              # k=19
+    5162283633 // 5,  # k=20
+    0,              # k=21
+    16397040750,    # k=22
+    0,              # k=23
+    266958797382,   # k=24
+]
+
+"""
+    ising_3D_free_energy_htse(β::Real; J::Real=1.0, max_order::Int=24)
+
+Compute the free energy per spin for the 3D Ising model on a simple cubic lattice
+using the high-temperature series expansion (HTSE) to 24th order.
+
+The expansion is taken from Bhanot, Creutz, Glässner, Schilling (hep-lat/9312048),
+Table 2, with the formula:
+
+    f(β) = -(1/β) * log(2*cosh(β*J)³) - (1/β) * Σ_{k} f_k * tanh(β*J)^k
+
+# Arguments
+- `β`: Inverse temperature.
+- `J`: Coupling constant (default: 1.0).
+- `max_order`: Maximum order of the series expansion (default: 24, max: 24).
+
+# Examples
+```julia
+julia> ising_3D_free_energy_htse(ising_βc_3D)
+-3.5083582548883747
+```
+"""
+function ising_3D_free_energy_htse(β::Real; J::Real = 1.0, max_order::Int = 24)
+    K = β * J
+    t = tanh(K)
+    f = -log(2 * cosh(K)^3) / β
+    series = zero(Float64)
+    t_pow = one(Float64)
+    kmax = min(max_order, length(ISING_3D_HTSE_COEFFS) - 1)
+    for k in 0:kmax
+        coeff = ISING_3D_HTSE_COEFFS[k + 1]
+        if !iszero(coeff)
+            series += Float64(coeff) * t_pow
+        end
+        t_pow *= t
+    end
+    f -= series / β
+    return f
+end
+
 function ising_bond_tensor(β::Real, T::Type{<:Number})
     x = cosh(β)
     y = sinh(β)

--- a/src/models/ising.jl
+++ b/src/models/ising.jl
@@ -9,31 +9,8 @@ const ising_βc_3D = 1.0 / 4.51152469
 
 # HTSE coefficients for the 3D Ising free energy (hep-lat/9312048, Table 2).
 const ISING_3D_HTSE_COEFFS = [
-    0,              # k=0
-    0,              # k=1
-    0,              # k=2
-    0,              # k=3
-    3,              # k=4
-    0,              # k=5
-    22,             # k=6
-    0,              # k=7
-    375 // 2,         # k=8
-    0,              # k=9
-    1980,           # k=10
-    0,              # k=11
-    24044,          # k=12
-    0,              # k=13
-    319170,         # k=14
-    0,              # k=15
-    18059031 // 4,    # k=16
-    0,              # k=17
-    201010408 // 3,   # k=18
-    0,              # k=19
-    5162283633 // 5,  # k=20
-    0,              # k=21
-    16397040750,    # k=22
-    0,              # k=23
-    266958797382,   # k=24
+    0, 0, 0, 0, 3, 0, 22, 0, 375 // 2, 0, 1980, 0, 24044, 0, 319170, 0,
+    18059031 // 4, 0, 201010408 // 3, 0, 5162283633 // 5, 0, 16397040750, 0, 266958797382,
 ]
 
 """
@@ -59,13 +36,13 @@ julia> ising_3D_free_energy_htse(ising_βc_3D)
 ```
 """
 function ising_3D_free_energy_htse(β::Real; J::Real = 1.0, max_order::Int = 24)
+    max_order <= 24 || error("3D Ising HTSE is only up to the 24th order.")
     K = β * J
     t = tanh(K)
     f = -log(2 * cosh(K)^3) / β
     series = zero(Float64)
     t_pow = one(Float64)
-    kmax = min(max_order, length(ISING_3D_HTSE_COEFFS) - 1)
-    for k in 0:kmax
+    for k in 0:max_order
         coeff = ISING_3D_HTSE_COEFFS[k + 1]
         if !iszero(coeff)
             series += Float64(coeff) * t_pow

--- a/test/schemes/schemes.jl
+++ b/test/schemes/schemes.jl
@@ -9,8 +9,7 @@ println("---------------------")
 
 T = classical_ising()
 T_3D = classical_ising_3D()
-# from Fig. 5 of Physical Review B 102, 054432 (2020)
-const f_benchmark3D = -3.507
+const f_benchmark3D = ising_3D_free_energy_htse(ising_βc_3D)
 
 function cft_finalize!(scheme)
     finalize!(scheme)


### PR DESCRIPTION
This PR replaces the hardcoded 3D Ising free energy (at critical temperature) by a high-temperature series expansion (up to $O(\beta^24)$) from Bhanot, Creutz, Glässner, Schilling (hep-lat/9312048). This can also allow us to get the free energy at other temperatures.

The original hardcoded free energy is -3.507. HTSE at $T_c$ gives -3.5083582548883747.