### PR TITLE
Enforce correct scalartype in transfermatrix diagonalisation

### DIFF
--- a/src/utility/transfer_matrix.jl
+++ b/src/utility/transfer_matrix.jl
@@ -379,7 +379,7 @@ function leading_eigenvalue(
         BraidingStyle(I) != Bosonic() || error("pbc = false only applies to fermionic tensors.")
     end
     V = (I == Trivial) ? field(tm.TA)^1 : Vect[I](charge => 1)
-    x = ones(domain(tm) ← V)
+    x = ones(E, domain(tm) ← V)
     dim(x) == 0 && error("$charge is not allowed by the transfer matrix.")
     tm′(x) = tm(x; pbc)
     spec, _, info = eigsolve(


### PR DESCRIPTION
The starting guess for the diagonalisation of transfermatrices did not use the scalartype information of the transfermatrix, leading to methoderrors when calling `CFTData` on schemes with complex tensors.

Thanks @dartsushi for pointing this out.